### PR TITLE
Suppress silent response notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ The plugin currently emits notifications for:
 - failed turns
 - completed delegated tasks
 
+An exact `[Silent]` assistant response does not emit a completion notification.
+
 The iOS app controls which categories are enabled, whether notification previews are shown, and whether completion sounds play.
 
 ## Privacy and security

--- a/__init__.py
+++ b/__init__.py
@@ -6,7 +6,7 @@ import threading
 from typing import Any
 
 from .client import enqueue
-from .events import clarification_text, event_id, push_event
+from .events import clarification_text, event_id, is_silent_response, push_event
 
 
 _child_sessions: set[str] = set()
@@ -47,14 +47,15 @@ def _pre_tool_call(**kwargs: Any) -> None:
 
 def _post_llm_call(**kwargs: Any) -> None:
     session_id = _text(kwargs.get("session_id"))
-    if _is_child(session_id):
+    response = kwargs.get("assistant_response")
+    if _is_child(session_id) or is_silent_response(response):
         return
     enqueue(push_event(
         "response.ready",
         identifier=event_id("response", kwargs.get("turn_id"), session_id),
         session_id=session_id,
         profile=_profile,
-        body=_text(kwargs.get("assistant_response")),
+        body=_text(response),
     ))
 
 

--- a/events.py
+++ b/events.py
@@ -54,5 +54,10 @@ def clarification_text(args: Any) -> str:
     return "Hermes needs your response before it can continue."
 
 
+def is_silent_response(value: Any) -> bool:
+    """Return true only for Hermes' exact no-notification response sentinel."""
+    return isinstance(value, str) and " ".join(value.split()).casefold() == "[silent]"
+
+
 def _clean(value: str, maximum: int) -> str:
     return " ".join(str(value).split())[:maximum]

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from events import clarification_text, event_id, push_event
+from events import clarification_text, event_id, is_silent_response, push_event
 
 
 def test_event_identifiers_are_stable_for_replayed_hooks():
@@ -27,3 +27,11 @@ def test_push_event_has_bounded_preview_and_session_context():
 def test_clarification_text_accepts_single_and_multiple_question_shapes():
     assert clarification_text({"question": "Choose one"}) == "Choose one"
     assert clarification_text({"questions": [{"question": "First question"}]}) == "First question"
+
+
+def test_silent_response_matches_only_the_exact_sentinel():
+    assert is_silent_response("[Silent]")
+    assert is_silent_response("  [silent]\n")
+    assert not is_silent_response("Response: [Silent]")
+    assert not is_silent_response("")
+    assert not is_silent_response(None)


### PR DESCRIPTION
Skips response-ready notifications when Hermes returns the exact [Silent] sentinel. Includes focused tests that preserve notifications for ordinary responses containing the word Silent.