### PR TITLE
Forward approval decision content through push payloads

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -76,9 +76,14 @@ def _pre_approval_request(**kwargs: Any) -> None:
         return
     session_id = _text(kwargs.get("session_key"))
     description = _text(kwargs.get("description"))
+    # The event id deliberately excludes `id(kwargs)`: CPython recycles ids, so
+    # a later, distinct approval with the same session/pattern/command could
+    # collide and be silently deduped by the relay for 24h. `turn_id` (forwarded
+    # by the approval hook) is stable across replays of one turn and distinct
+    # across turns, which is exactly the dedupe semantics the relay wants.
     enqueue(push_event(
         "approval.needed",
-        identifier=event_id("approval", session_id, kwargs.get("pattern_key"), kwargs.get("command"), id(kwargs)),
+        identifier=event_id("approval", session_id, kwargs.get("turn_id"), kwargs.get("pattern_key"), kwargs.get("command")),
         session_id=session_id,
         profile=_profile,
         body=description or "Hermes is waiting for your approval.",

--- a/__init__.py
+++ b/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import threading
+import uuid
 from typing import Any
 
 from .client import enqueue
@@ -80,10 +81,14 @@ def _pre_approval_request(**kwargs: Any) -> None:
     # a later, distinct approval with the same session/pattern/command could
     # collide and be silently deduped by the relay for 24h. `turn_id` (forwarded
     # by the approval hook) is stable across replays of one turn and distinct
-    # across turns, which is exactly the dedupe semantics the relay wants.
+    # across turns. When the hook carries no turn id, fall back to a unique id
+    # per raise: two identical commands approved in sequence must both notify,
+    # and the plugin's delivery queue never retries, so a stable id has no
+    # at-least-once role to play there.
+    turn_id = kwargs.get("turn_id") or uuid.uuid4().hex
     enqueue(push_event(
         "approval.needed",
-        identifier=event_id("approval", session_id, kwargs.get("turn_id"), kwargs.get("pattern_key"), kwargs.get("command")),
+        identifier=event_id("approval", session_id, turn_id, kwargs.get("pattern_key"), kwargs.get("command")),
         session_id=session_id,
         profile=_profile,
         body=description or "Hermes is waiting for your approval.",

--- a/__init__.py
+++ b/__init__.py
@@ -6,7 +6,7 @@ import threading
 from typing import Any
 
 from .client import enqueue
-from .events import clarification_text, event_id, is_silent_response, push_event
+from .events import approval_decision, clarification_text, event_id, is_silent_response, push_event
 
 
 _child_sessions: set[str] = set()
@@ -75,12 +75,19 @@ def _pre_approval_request(**kwargs: Any) -> None:
     if kwargs.get("surface") == "smart":
         return
     session_id = _text(kwargs.get("session_key"))
+    description = _text(kwargs.get("description"))
     enqueue(push_event(
         "approval.needed",
         identifier=event_id("approval", session_id, kwargs.get("pattern_key"), kwargs.get("command"), id(kwargs)),
         session_id=session_id,
         profile=_profile,
-        body=_text(kwargs.get("description")) or "Hermes is waiting for your approval.",
+        body=description or "Hermes is waiting for your approval.",
+        # Attach the structured card so Conduit can render an answerable
+        # approval from the push payload while backgrounded. Requires a
+        # session_key so the user's choice can be routed back via
+        # approval.respond {choice, session_id}. The raw command is omitted
+        # (see approval_decision) to avoid echoing secrets through APNs.
+        decision=approval_decision(session_key=session_id, description=description) if session_id else None,
     ))
 
 

--- a/__init__.py
+++ b/__init__.py
@@ -83,11 +83,17 @@ def _pre_approval_request(**kwargs: Any) -> None:
         profile=_profile,
         body=description or "Hermes is waiting for your approval.",
         # Attach the structured card so Conduit can render an answerable
-        # approval from the push payload while backgrounded. Requires a
-        # session_key so the user's choice can be routed back via
-        # approval.respond {choice, session_id}. The raw command is omitted
-        # (see approval_decision) to avoid echoing secrets through APNs.
-        decision=approval_decision(session_key=session_id, description=description) if session_id else None,
+        # approval from the push payload while backgrounded. Requires both a
+        # session_key (to route the choice back via approval.respond) and a
+        # description (the card's display text); without either, the
+        # sanitizer would reject it anyway, so skip the dead build.
+        # The raw command is omitted (see approval_decision) to avoid
+        # echoing secrets through APNs.
+        decision=(
+            approval_decision(session_key=session_id, description=description)
+            if session_id and description
+            else None
+        ),
     ))
 
 

--- a/events.py
+++ b/events.py
@@ -38,13 +38,12 @@ def push_event(
     # `decision` carries the structured card content that lets Conduit render
     # an answerable card from the push payload alone, without the one-shot
     # gateway stream event (which is missed while the app is backgrounded).
-    # It is optional, only meaningful for decision notifications, and the
-    # decision kind must match the event type (approval.needed -> approval,
-    # input.needed -> clarify) so the two can never disagree.
-    if decision and kind in ("approval.needed", "input.needed"):
+    # Only the approval contract is shipped: clarify is not answerable from a
+    # payload (its request id is minted gateway-side), and the relay rejects
+    # it, so it is not emitted or accepted here until that phase exists.
+    if decision and kind == "approval.needed":
         sanitized = sanitize_decision(decision)
-        expected_kind = "approval" if kind == "approval.needed" else "clarify"
-        if sanitized and sanitized.get("kind") == expected_kind:
+        if sanitized:
             event["decision"] = sanitized
     return event
 
@@ -73,15 +72,17 @@ def sanitize_decision(decision: dict[str, Any]) -> dict[str, Any]:
 
     Defense in depth: the relay re-validates, but keep this side bounded too
     so a malformed hook payload can never push an oversized or unknown-shaped
-    object through to the relay/APNs.
+    object through to the relay/APNs. Mirrors the relay's contract: approval
+    only (clarify is rejected there until it is answerable from a payload),
+    requiring the session key that routes the answer and the description that
+    renders the card.
     """
     if not isinstance(decision, dict):
         return {}
-    kind = _clean(decision.get("kind", ""), 40)
-    if kind not in ("approval", "clarify"):
+    if _clean(decision.get("kind", ""), 40) != "approval":
         return {}
-    sanitized: dict[str, Any] = {"kind": kind}
-    for key in ("session_key", "request_id", "question", "description"):
+    sanitized: dict[str, Any] = {"kind": "approval"}
+    for key in ("session_key", "description"):
         value = _clean(decision.get(key, ""), 500)
         if value:
             sanitized[key] = value
@@ -92,13 +93,11 @@ def sanitize_decision(decision: dict[str, Any]) -> dict[str, Any]:
         cleaned = [value for value in (_clean(choice, 80) for choice in choices) if value]
         if cleaned:
             sanitized["choices"] = cleaned[:8]
-    # Require both something to display and the key needed to answer it,
-    # otherwise the card is useless and the notification should degrade to the
-    # plain routing stub. Approval responds by session_key; clarify by
-    # request_id. (Clarify content ships in a later phase.)
-    has_display = bool(sanitized.get("description") or sanitized.get("question"))
-    answerable = sanitized.get("session_key") if kind == "approval" else sanitized.get("request_id")
-    if not has_display or not answerable:
+    # Require both something to display, the key needed to answer it, and at
+    # least one usable choice — the same shape the relay enforces.
+    if not sanitized.get("description") or not sanitized.get("session_key"):
+        return {}
+    if not sanitized.get("choices"):
         return {}
     return sanitized
 

--- a/events.py
+++ b/events.py
@@ -24,6 +24,7 @@ def push_event(
     profile: str = "default",
     title: str = "",
     body: str = "",
+    decision: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     event: dict[str, Any] = {"event_id": identifier, "type": kind}
     if session_id:
@@ -34,7 +35,68 @@ def push_event(
         event["title"] = _clean(title, 120)
     if body:
         event["body"] = _clean(body, 500)
+    # `decision` carries the structured card content that lets Conduit render
+    # an answerable card from the push payload alone, without the one-shot
+    # gateway stream event (which is missed while the app is backgrounded).
+    # It is optional and only meaningful for decision notifications, so it is
+    # ignored for any other event type even if a caller passes it.
+    if decision and kind in ("approval.needed", "input.needed"):
+        sanitized = sanitize_decision(decision)
+        if sanitized:
+            event["decision"] = sanitized
     return event
+
+
+def approval_decision(*, session_key: str, description: str) -> dict[str, Any]:
+    """Build the structured payload for an approval notification.
+
+    The `pre_approval_request` hook exposes `description` and `session_key` but
+    not the allow_session/allow_permanent flags, so the exact server-side choice
+    set is unknown here. ``once`` and ``deny`` are always valid choices (Hermes
+    builds every `ApprovalRequest` with at least those two), so the push card
+    offers that always-safe subset; the live foreground card still shows the
+    full set. The raw `command` is intentionally omitted — it can carry
+    secrets, and the relay/APNs path is an extra egress transport.
+    """
+    return {
+        "kind": "approval",
+        "session_key": session_key,
+        "description": description,
+        "choices": ["once", "deny"],
+    }
+
+
+def sanitize_decision(decision: dict[str, Any]) -> dict[str, Any]:
+    """Bound and whitelist a decision payload before it leaves the gateway.
+
+    Defense in depth: the relay re-validates, but keep this side bounded too
+    so a malformed hook payload can never push an oversized or unknown-shaped
+    object through to the relay/APNs.
+    """
+    if not isinstance(decision, dict):
+        return {}
+    kind = _clean(decision.get("kind", ""), 40)
+    if kind not in ("approval", "clarify"):
+        return {}
+    sanitized: dict[str, Any] = {"kind": kind}
+    for key in ("session_key", "request_id", "question", "description"):
+        value = _clean(decision.get(key, ""), 500)
+        if value:
+            sanitized[key] = value
+    choices = decision.get("choices")
+    if isinstance(choices, list):
+        cleaned = [_clean(str(choice), 80) for choice in choices if str(choice).strip()]
+        if cleaned:
+            sanitized["choices"] = cleaned[:8]
+    # Require both something to display and the key needed to answer it,
+    # otherwise the card is useless and the notification should degrade to the
+    # plain routing stub. Approval responds by session_key; clarify by
+    # request_id. (Clarify content ships in a later phase.)
+    has_display = bool(sanitized.get("description") or sanitized.get("question"))
+    answerable = sanitized.get("session_key") if kind == "approval" else sanitized.get("request_id")
+    if not has_display or not answerable:
+        return {}
+    return sanitized
 
 
 def clarification_text(args: Any) -> str:

--- a/events.py
+++ b/events.py
@@ -38,11 +38,13 @@ def push_event(
     # `decision` carries the structured card content that lets Conduit render
     # an answerable card from the push payload alone, without the one-shot
     # gateway stream event (which is missed while the app is backgrounded).
-    # It is optional and only meaningful for decision notifications, so it is
-    # ignored for any other event type even if a caller passes it.
+    # It is optional, only meaningful for decision notifications, and the
+    # decision kind must match the event type (approval.needed -> approval,
+    # input.needed -> clarify) so the two can never disagree.
     if decision and kind in ("approval.needed", "input.needed"):
         sanitized = sanitize_decision(decision)
-        if sanitized:
+        expected_kind = "approval" if kind == "approval.needed" else "clarify"
+        if sanitized and sanitized.get("kind") == expected_kind:
             event["decision"] = sanitized
     return event
 
@@ -85,7 +87,9 @@ def sanitize_decision(decision: dict[str, Any]) -> dict[str, Any]:
             sanitized[key] = value
     choices = decision.get("choices")
     if isinstance(choices, list):
-        cleaned = [_clean(str(choice), 80) for choice in choices if str(choice).strip()]
+        # Clean first, then drop empties: filtering on the raw value would
+        # coerce None to the truthy "None" and forward it as a choice.
+        cleaned = [value for value in (_clean(choice, 80) for choice in choices) if value]
         if cleaned:
             sanitized["choices"] = cleaned[:8]
     # Require both something to display and the key needed to answer it,
@@ -122,4 +126,10 @@ def is_silent_response(value: Any) -> bool:
 
 
 def _clean(value: str, maximum: int) -> str:
-    return " ".join(str(value).split())[:maximum]
+    # Non-strings (None, numbers, nested objects) must not be coerced —
+    # str(None) would produce a truthy "None" that slips past emptiness
+    # checks and gets forwarded to the relay. Drop them instead, matching
+    # the relay's cleanText semantics.
+    if not isinstance(value, str):
+        return ""
+    return " ".join(value.split())[:maximum]

--- a/relay/src/server.mjs
+++ b/relay/src/server.mjs
@@ -179,10 +179,13 @@ function notificationFor(event, preferences) {
   const completion = event.type === 'response.ready' || event.type === 'background_task.finished';
   // `decision` carries structured approval card content so Conduit can render
   // an answerable card from the push payload alone — the one-shot gateway
-  // stream event is missed while the app is backgrounded. It is preview text
-  // exactly like `title`/`body`, so it is gated on show_previews; a user who
-  // disabled previews keeps approval descriptions off the payload entirely.
-  const decision = preferences.show_previews
+  // stream event is missed while the app is backgrounded. It has its own
+  // dedicated `decision_cards` preference (default on, independent of
+  // show_previews): previews only control banner text, while this controls
+  // functional answerability, and the audience running approval gates is
+  // exactly who the cards are for. `!== false` keeps legacy installations
+  // (whose stored preferences predate the key) on the default.
+  const decision = preferences.decision_cards !== false
     ? validateDecision(event.decision, event.type)
     : undefined;
   const routing = {

--- a/relay/src/server.mjs
+++ b/relay/src/server.mjs
@@ -1,30 +1,45 @@
 import { createServer } from 'node:http';
 import { isIP } from 'node:net';
+import { pathToFileURL } from 'node:url';
 import { ApnsClient } from './apns.mjs';
 import { RelayStore } from './store.mjs';
 
-const config = readConfig();
-const store = new RelayStore(config.dataPath);
-const apns = new ApnsClient(config);
-const limits = new Map();
+let config;
+let store;
+let apns;
+let limits;
 
-const server = createServer(async (request, response) => {
-  const startedAt = Date.now();
-  try {
-    await route(request, response);
-  } catch (error) {
-    const status = Number(error?.status ?? 500);
-    const code = status < 500 && error instanceof Error ? error.message : 'internal_error';
-    if (status >= 500) console.error(JSON.stringify({ level: 'error', message: 'request failed', error: error instanceof Error ? error.message : String(error) }));
-    sendJson(response, status, { error: code });
-  } finally {
-    console.log(JSON.stringify({ level: 'info', method: request.method, path: safePath(request.url), status: response.statusCode, duration_ms: Date.now() - startedAt }));
-  }
-});
+function main() {
+  config = readConfig();
+  store = new RelayStore(config.dataPath);
+  apns = new ApnsClient(config);
+  limits = new Map();
 
-server.listen(config.port, config.host, () => {
-  console.log(JSON.stringify({ level: 'info', message: 'Conduit push relay listening', host: config.host, port: config.port, public_url: config.publicUrl }));
-});
+  const server = createServer(async (request, response) => {
+    const startedAt = Date.now();
+    try {
+      await route(request, response);
+    } catch (error) {
+      const status = Number(error?.status ?? 500);
+      const code = status < 500 && error instanceof Error ? error.message : 'internal_error';
+      if (status >= 500) console.error(JSON.stringify({ level: 'error', message: 'request failed', error: error instanceof Error ? error.message : String(error) }));
+      sendJson(response, status, { error: code });
+    } finally {
+      console.log(JSON.stringify({ level: 'info', method: request.method, path: safePath(request.url), status: response.statusCode, duration_ms: Date.now() - startedAt }));
+    }
+  });
+
+  server.listen(config.port, config.host, () => {
+    console.log(JSON.stringify({ level: 'info', message: 'Conduit push relay listening', host: config.host, port: config.port, public_url: config.publicUrl }));
+  });
+
+  process.on('SIGTERM', () => server.close(() => process.exit(0)));
+  process.on('SIGINT', () => server.close(() => process.exit(0)));
+}
+
+// Start the server only when executed directly, so the pure notification
+// builders can be unit-tested by importing this module without binding a port.
+if (pathToFileURL(process.argv[1] ?? '').href === import.meta.url) main();
 
 async function route(request, response) {
   const url = new URL(request.url ?? '/', config.publicUrl);
@@ -135,6 +150,18 @@ function notificationFor(event, preferences) {
   // different profiles and sessions distinguishable in Notification Center.
   const body = preferences.show_previews && event.body ? event.body : notificationContext(generic.body, event);
   const completion = event.type === 'response.ready' || event.type === 'background_task.finished';
+  // `decision` carries structured card content (approval/clarify) so Conduit
+  // can render an answerable card from the push payload alone — the one-shot
+  // gateway stream event is missed while the app is backgrounded. The plugin
+  // already bounds/whitelists it; re-validate here as the trust boundary.
+  const decision = validateDecision(event.decision);
+  const conduit = {
+    type: event.type,
+    session_id: event.sessionId,
+    profile: event.profile,
+    gateway: event.gateway,
+    ...(decision ? { decision } : {}),
+  };
   return {
     collapseId: event.sessionId ? `${event.type}:${event.sessionId}` : event.eventId,
     payload: {
@@ -147,20 +174,8 @@ function notificationFor(event, preferences) {
       // `notification.request.content.data`. Keep the Conduit route there so
       // a notification tap can recover its session/profile after a cold start.
       // The top-level copy remains for clients that read the raw APNs payload.
-      body: {
-        conduit: {
-          type: event.type,
-          session_id: event.sessionId,
-          profile: event.profile,
-          gateway: event.gateway,
-        },
-      },
-      conduit: {
-        type: event.type,
-        session_id: event.sessionId,
-        profile: event.profile,
-        gateway: event.gateway,
-      },
+      body: { conduit },
+      conduit,
     },
   };
 }
@@ -202,7 +217,30 @@ function validateEvent(body) {
     sessionId: cleanIdentifier(body.session_id, 180),
     profile: cleanText(body.profile, 80),
     gateway: cleanIdentifier(body.gateway, 80),
+    decision: validateDecision(body.decision),
   };
+}
+
+// Mirror the plugin's decision sanitization at the relay trust boundary: bound
+// field sizes, whitelist the kind, and require both a display field and the
+// answerability key (approval: session_key; clarify: request_id). Anything
+// malformed degrades to undefined and the notification ships as a routing stub.
+function validateDecision(value) {
+  if (!value || typeof value !== 'object') return undefined;
+  const kind = cleanText(value.kind, 40);
+  if (kind !== 'approval' && kind !== 'clarify') return undefined;
+  const decision = { kind };
+  for (const key of ['session_key', 'request_id', 'question', 'description']) {
+    const text = cleanText(value[key], 500);
+    if (text) decision[key] = text;
+  }
+  if (Array.isArray(value.choices)) {
+    const choices = value.choices.map((c) => cleanText(c, 80)).filter((c) => c !== undefined);
+    if (choices.length) decision.choices = choices.slice(0, 8);
+  }
+  const hasDisplay = Boolean(decision.description || decision.question);
+  const answerable = kind === 'approval' ? decision.session_key : decision.request_id;
+  return hasDisplay && answerable ? decision : undefined;
 }
 
 function validateDeviceToken(value) {
@@ -285,5 +323,4 @@ function readConfig() {
   };
 }
 
-process.on('SIGTERM', () => server.close(() => process.exit(0)));
-process.on('SIGINT', () => server.close(() => process.exit(0)));
+export { notificationFor, validateEvent, validateDecision };

--- a/relay/src/server.mjs
+++ b/relay/src/server.mjs
@@ -10,6 +10,11 @@ let store;
 let apns;
 let limits;
 
+// APNs hard-caps a notification payload at 4096 bytes; stay under it with
+// headroom for JSON escaping and delivery headers, dropping decision content
+// (not the notification) when a payload would exceed the bound.
+const MAX_NOTIFICATION_BYTES = 3800;
+
 function main() {
   config = readConfig();
   store = new RelayStore(config.dataPath);
@@ -41,7 +46,9 @@ function main() {
 // Start the server only when executed directly, so the pure notification
 // builders can be unit-tested by importing this module without binding a port.
 // Resolve argv[1] through realpath so a symlinked entrypoint still matches
-// import.meta.url (which Node resolves to the real file).
+// import.meta.url (which Node resolves to the real file). If an entrypoint
+// exists but does not match, say so on stderr — a silent no-op start is the
+// worst possible deployment failure mode.
 function isEntryPoint() {
   if (!process.argv[1]) return false;
   try {
@@ -50,7 +57,16 @@ function isEntryPoint() {
     return false;
   }
 }
-if (isEntryPoint()) main();
+if (isEntryPoint()) {
+  main();
+} else if (process.argv[1] && !process.env.NODE_TEST_CONTEXT) {
+  console.error(JSON.stringify({
+    level: 'warn',
+    message: 'relay module imported without matching entrypoint; not starting server',
+    argv1: process.argv[1],
+    module: import.meta.url,
+  }));
+}
 
 async function route(request, response) {
   const url = new URL(request.url ?? '/', config.publicUrl);
@@ -187,10 +203,11 @@ function notificationFor(event, preferences) {
   // The top-level copy remains for clients that read the raw APNs payload.
   let payload = { aps, body: { conduit }, conduit };
   // APNs caps the notification payload at 4 KB and rejects anything larger.
-  // A maximal description (500 chars of multi-byte UTF-8) plus the alert copy
-  // can approach that, so degrade to the routing stub instead of losing the
-  // whole notification.
-  if (decision && Buffer.byteLength(JSON.stringify(payload)) > 3800) {
+  // A maximal description (500 chars of multi-byte UTF-8, echoed in both
+  // conduit copies) plus the alert copy can approach that, so degrade to the
+  // routing stub instead of losing the whole notification. The headroom under
+  // the 4096 cap absorbs per-request APNs headers and JSON escaping.
+  if (decision && Buffer.byteLength(JSON.stringify(payload)) > MAX_NOTIFICATION_BYTES) {
     payload = { aps, body: { conduit: routing }, conduit: routing };
   }
   return {

--- a/relay/src/server.mjs
+++ b/relay/src/server.mjs
@@ -1,4 +1,5 @@
 import { createServer } from 'node:http';
+import { realpathSync } from 'node:fs';
 import { isIP } from 'node:net';
 import { pathToFileURL } from 'node:url';
 import { ApnsClient } from './apns.mjs';
@@ -39,7 +40,17 @@ function main() {
 
 // Start the server only when executed directly, so the pure notification
 // builders can be unit-tested by importing this module without binding a port.
-if (pathToFileURL(process.argv[1] ?? '').href === import.meta.url) main();
+// Resolve argv[1] through realpath so a symlinked entrypoint still matches
+// import.meta.url (which Node resolves to the real file).
+function isEntryPoint() {
+  if (!process.argv[1]) return false;
+  try {
+    return pathToFileURL(realpathSync(process.argv[1])).href === import.meta.url;
+  } catch {
+    return false;
+  }
+}
+if (isEntryPoint()) main();
 
 async function route(request, response) {
   const url = new URL(request.url ?? '/', config.publicUrl);
@@ -150,33 +161,41 @@ function notificationFor(event, preferences) {
   // different profiles and sessions distinguishable in Notification Center.
   const body = preferences.show_previews && event.body ? event.body : notificationContext(generic.body, event);
   const completion = event.type === 'response.ready' || event.type === 'background_task.finished';
-  // `decision` carries structured card content (approval/clarify) so Conduit
-  // can render an answerable card from the push payload alone — the one-shot
-  // gateway stream event is missed while the app is backgrounded. The plugin
-  // already bounds/whitelists it; re-validate here as the trust boundary.
-  const decision = validateDecision(event.decision);
-  const conduit = {
+  // `decision` carries structured approval card content so Conduit can render
+  // an answerable card from the push payload alone — the one-shot gateway
+  // stream event is missed while the app is backgrounded. It is preview text
+  // exactly like `title`/`body`, so it is gated on show_previews; a user who
+  // disabled previews keeps approval descriptions off the payload entirely.
+  const decision = preferences.show_previews
+    ? validateDecision(event.decision, event.type)
+    : undefined;
+  const routing = {
     type: event.type,
     session_id: event.sessionId,
     profile: event.profile,
     gateway: event.gateway,
-    ...(decision ? { decision } : {}),
   };
+  const conduit = { ...routing, ...(decision ? { decision } : {}) };
+  const aps = {
+    alert: { title, body },
+    ...(preferences.completion_sound && completion ? { sound: 'default' } : {}),
+    'thread-id': event.sessionId ?? 'hermes',
+  };
+  // expo-notifications on iOS exposes the top-level APNs `body` value as
+  // `notification.request.content.data`. Keep the Conduit route there so
+  // a notification tap can recover its session/profile after a cold start.
+  // The top-level copy remains for clients that read the raw APNs payload.
+  let payload = { aps, body: { conduit }, conduit };
+  // APNs caps the notification payload at 4 KB and rejects anything larger.
+  // A maximal description (500 chars of multi-byte UTF-8) plus the alert copy
+  // can approach that, so degrade to the routing stub instead of losing the
+  // whole notification.
+  if (decision && Buffer.byteLength(JSON.stringify(payload)) > 3800) {
+    payload = { aps, body: { conduit: routing }, conduit: routing };
+  }
   return {
     collapseId: event.sessionId ? `${event.type}:${event.sessionId}` : event.eventId,
-    payload: {
-      aps: {
-        alert: { title, body },
-        ...(preferences.completion_sound && completion ? { sound: 'default' } : {}),
-        'thread-id': event.sessionId ?? 'hermes',
-      },
-      // expo-notifications on iOS exposes the top-level APNs `body` value as
-      // `notification.request.content.data`. Keep the Conduit route there so
-      // a notification tap can recover its session/profile after a cold start.
-      // The top-level copy remains for clients that read the raw APNs payload.
-      body: { conduit },
-      conduit,
-    },
+    payload,
   };
 }
 
@@ -217,30 +236,32 @@ function validateEvent(body) {
     sessionId: cleanIdentifier(body.session_id, 180),
     profile: cleanText(body.profile, 80),
     gateway: cleanIdentifier(body.gateway, 80),
-    decision: validateDecision(body.decision),
+    decision: validateDecision(body.decision, body.type),
   };
 }
 
-// Mirror the plugin's decision sanitization at the relay trust boundary: bound
-// field sizes, whitelist the kind, and require both a display field and the
-// answerability key (approval: session_key; clarify: request_id). Anything
-// malformed degrades to undefined and the notification ships as a routing stub.
-function validateDecision(value) {
+// Mirror the plugin's decision sanitization at the relay trust boundary.
+// Only the approval contract is shipped: a clarify decision cannot be answered
+// from the payload (its request id is minted gateway-side), so it is rejected
+// until that phase exists, and the kind must agree with the event type.
+// Choices are whitelisted to the gateway's approval vocabulary so a
+// compromised gateway cannot inject arbitrary button text into the payload.
+// Anything malformed degrades to undefined and the notification ships as a
+// routing stub.
+function validateDecision(value, eventType) {
   if (!value || typeof value !== 'object') return undefined;
-  const kind = cleanText(value.kind, 40);
-  if (kind !== 'approval' && kind !== 'clarify') return undefined;
-  const decision = { kind };
-  for (const key of ['session_key', 'request_id', 'question', 'description']) {
-    const text = cleanText(value[key], 500);
-    if (text) decision[key] = text;
-  }
-  if (Array.isArray(value.choices)) {
-    const choices = value.choices.map((c) => cleanText(c, 80)).filter((c) => c !== undefined);
-    if (choices.length) decision.choices = choices.slice(0, 8);
-  }
-  const hasDisplay = Boolean(decision.description || decision.question);
-  const answerable = kind === 'approval' ? decision.session_key : decision.request_id;
-  return hasDisplay && answerable ? decision : undefined;
+  if (cleanText(value.kind, 40) !== 'approval' || eventType !== 'approval.needed') return undefined;
+  const sessionKey = cleanIdentifier(value.session_key, 180);
+  const description = cleanText(value.description, 500);
+  if (!sessionKey || !description) return undefined;
+  const allowed = new Set(['once', 'session', 'always', 'deny']);
+  const choices = [...new Set(
+    (Array.isArray(value.choices) ? value.choices : [])
+      .map((choice) => cleanText(choice, 80))
+      .filter((choice) => allowed.has(choice)),
+  )];
+  if (!choices.length) return undefined;
+  return { kind: 'approval', session_key: sessionKey, description, choices };
 }
 
 function validateDeviceToken(value) {

--- a/relay/src/store.mjs
+++ b/relay/src/store.mjs
@@ -11,6 +11,11 @@ const defaultPreferences = Object.freeze({
   background_task_finished: true,
   completion_sound: true,
   show_previews: false,
+  // Dedicated opt-out for structured decision content (answerable approval
+  // cards) in the push payload. Deliberately independent of show_previews:
+  // the feature's audience is exactly the approval-gate crowd, so cards
+  // default on and privacy-focused users can turn just this off.
+  decision_cards: true,
 });
 
 export class RelayStore {

--- a/relay/test/server.test.mjs
+++ b/relay/test/server.test.mjs
@@ -4,6 +4,14 @@ import { test } from 'node:test';
 import { notificationFor, validateEvent, validateDecision } from '../src/server.mjs';
 
 const preferences = { show_previews: true, completion_sound: false };
+const privatePreferences = { show_previews: false, completion_sound: false };
+
+const approvalDecision = {
+  kind: 'approval',
+  session_key: 'sess-1',
+  description: 'Run a dangerous shell command',
+  choices: ['once', 'deny'],
+};
 
 test('notificationFor embeds a valid decision in both conduit payload paths', () => {
   const event = {
@@ -11,7 +19,7 @@ test('notificationFor embeds a valid decision in both conduit payload paths', ()
     type: 'approval.needed',
     sessionId: 'sess-1',
     profile: 'default',
-    decision: { kind: 'approval', session_key: 'sess-1', description: 'Run a dangerous shell command', choices: ['once', 'deny'] },
+    decision: approvalDecision,
   };
   const { payload } = notificationFor(event, preferences);
   assert.equal(payload.conduit.decision.kind, 'approval');
@@ -41,7 +49,77 @@ test('notificationFor drops a malformed decision so the notification degrades to
   assert.equal(payload.conduit.decision, undefined);
 });
 
-test('validateEvent passes through a bounded decision', () => {
+test('notificationFor omits decision when show_previews is disabled', () => {
+  // Decision content is preview text, exactly like title/body: a user who
+  // disabled previews must not have approval descriptions in the payload.
+  const event = {
+    eventId: 'approval:12345678',
+    type: 'approval.needed',
+    sessionId: 'sess-1',
+    profile: 'default',
+    decision: approvalDecision,
+  };
+  const { payload } = notificationFor(event, privatePreferences);
+  assert.equal(payload.conduit.decision, undefined);
+  assert.equal(payload.body.conduit.decision, undefined);
+  // Routing fields still flow so the tap still opens the right session.
+  assert.equal(payload.conduit.session_id, 'sess-1');
+});
+
+test('notificationFor degrades to a routing stub when the payload would exceed the APNs cap', () => {
+  const event = {
+    eventId: 'approval:12345678',
+    type: 'approval.needed',
+    sessionId: 'sess-1',
+    profile: 'default',
+    title: 'Approval needed',
+    // 500 multi-byte chars in the alert body plus a 500-char multi-byte
+    // description (echoed in both conduit copies) push the encoded payload
+    // past the 4 KB APNs cap.
+    body: '€'.repeat(500),
+    decision: { ...approvalDecision, description: '€'.repeat(500) },
+  };
+  const { payload } = notificationFor(event, preferences);
+  assert.equal(payload.conduit.decision, undefined, 'oversized decision must be dropped');
+  assert.equal(payload.conduit.session_id, 'sess-1', 'routing stub must survive');
+  assert.ok(Buffer.byteLength(JSON.stringify(payload)) <= 3800);
+});
+
+test('validateDecision only accepts approval decisions on approval events', () => {
+  assert.equal(validateDecision(approvalDecision, 'approval.needed').kind, 'approval');
+  // Not shipped yet: clarify cannot be answered from the payload.
+  assert.equal(validateDecision({ kind: 'clarify', request_id: 'r', question: 'q' }, 'input.needed'), undefined);
+  // Kind and event type must agree.
+  assert.equal(validateDecision(approvalDecision, 'input.needed'), undefined);
+  assert.equal(validateDecision(approvalDecision, 'response.ready'), undefined);
+  assert.equal(validateDecision({ kind: 'sudo', session_key: 's', description: 'd', choices: ['once'] }, 'approval.needed'), undefined);
+});
+
+test('validateDecision whitelists choices to the approval vocabulary', () => {
+  const injected = validateDecision(
+    { ...approvalDecision, choices: ['once', 'deny', 'not-a-real-choice', 'free text'] },
+    'approval.needed',
+  );
+  assert.deepEqual(injected.choices, ['once', 'deny']);
+  // All-invalid choices degrade the whole decision to a routing stub.
+  assert.equal(
+    validateDecision({ ...approvalDecision, choices: ['bogus'] }, 'approval.needed'),
+    undefined,
+  );
+  // Missing or empty choices likewise.
+  assert.equal(validateDecision({ kind: 'approval', session_key: 's', description: 'd' }, 'approval.needed'), undefined);
+});
+
+test('validateDecision rejects missing display text or session key', () => {
+  assert.equal(validateDecision({ kind: 'approval', session_key: 's', choices: ['once'] }, 'approval.needed'), undefined);
+  assert.equal(validateDecision({ kind: 'approval', description: 'd', choices: ['once'] }, 'approval.needed'), undefined);
+  assert.equal(validateDecision(undefined, 'approval.needed'), undefined);
+  // Unknown fields are never echoed into the payload.
+  const clean = validateDecision({ ...approvalDecision, command: 'secret' }, 'approval.needed');
+  assert.equal(clean.command, undefined);
+});
+
+test('validateEvent passes a bounded decision through', () => {
   const event = validateEvent({
     type: 'approval.needed',
     event_id: 'approval:12345678',
@@ -51,14 +129,5 @@ test('validateEvent passes through a bounded decision', () => {
   assert.equal(event.decision.kind, 'approval');
   assert.equal(event.decision.session_key, 'sess-1');
   assert.equal(event.decision.description.length, 500);
-  assert.equal(event.decision.choices.length, 3); // all retained, each bounded
-  assert.ok(event.decision.choices.every((c) => c.length <= 80));
-});
-
-test('validateDecision rejects unknown kinds and non-answerable payloads', () => {
-  assert.equal(validateDecision(undefined), undefined);
-  assert.equal(validateDecision({ kind: 'sudo', description: 'x', session_key: 's' }), undefined);
-  assert.equal(validateDecision({ kind: 'approval', description: 'x' }), undefined); // no session_key
-  assert.equal(validateDecision({ kind: 'clarify', question: 'q' }), undefined); // no request_id
-  assert.equal(validateDecision({ kind: 'approval', session_key: 's', description: 'd', command: 'secret' }).command, undefined, 'unknown fields are not echoed');
+  assert.deepEqual(event.decision.choices, ['once', 'deny'], 'unknown choice strings are filtered');
 });

--- a/relay/test/server.test.mjs
+++ b/relay/test/server.test.mjs
@@ -4,7 +4,6 @@ import { test } from 'node:test';
 import { notificationFor, validateEvent, validateDecision } from '../src/server.mjs';
 
 const preferences = { show_previews: true, completion_sound: false };
-const privatePreferences = { show_previews: false, completion_sound: false };
 
 const approvalDecision = {
   kind: 'approval',
@@ -49,9 +48,7 @@ test('notificationFor drops a malformed decision so the notification degrades to
   assert.equal(payload.conduit.decision, undefined);
 });
 
-test('notificationFor omits decision when show_previews is disabled', () => {
-  // Decision content is preview text, exactly like title/body: a user who
-  // disabled previews must not have approval descriptions in the payload.
+test('notificationFor gates decision on the dedicated decision_cards preference', () => {
   const event = {
     eventId: 'approval:12345678',
     type: 'approval.needed',
@@ -59,11 +56,18 @@ test('notificationFor omits decision when show_previews is disabled', () => {
     profile: 'default',
     decision: approvalDecision,
   };
-  const { payload } = notificationFor(event, privatePreferences);
-  assert.equal(payload.conduit.decision, undefined);
-  assert.equal(payload.body.conduit.decision, undefined);
-  // Routing fields still flow so the tap still opens the right session.
-  assert.equal(payload.conduit.session_id, 'sess-1');
+  // Decision cards are independent of show_previews: previews-off users who
+  // left decision_cards on still get answerable cards...
+  const previewsOff = notificationFor(event, { show_previews: false, completion_sound: false });
+  assert.ok(previewsOff.payload.conduit.decision, 'previews-off must not disable decision cards');
+  assert.equal(previewsOff.payload.aps.alert.body.includes('Run a dangerous'), false, 'banner text stays generic');
+  // ...and turning just decision_cards off keeps the payload content-free.
+  const cardsOff = notificationFor(event, { show_previews: true, decision_cards: false, completion_sound: false });
+  assert.equal(cardsOff.payload.conduit.decision, undefined);
+  assert.equal(cardsOff.payload.body.conduit.decision, undefined);
+  // Legacy installations whose stored preferences predate the key default on.
+  const legacy = notificationFor(event, { show_previews: false, completion_sound: false });
+  assert.ok(legacy.payload.conduit.decision !== undefined);
 });
 
 test('notificationFor degrades to a routing stub when the payload would exceed the APNs cap', () => {

--- a/relay/test/server.test.mjs
+++ b/relay/test/server.test.mjs
@@ -1,0 +1,64 @@
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+
+import { notificationFor, validateEvent, validateDecision } from '../src/server.mjs';
+
+const preferences = { show_previews: true, completion_sound: false };
+
+test('notificationFor embeds a valid decision in both conduit payload paths', () => {
+  const event = {
+    eventId: 'approval:12345678',
+    type: 'approval.needed',
+    sessionId: 'sess-1',
+    profile: 'default',
+    decision: { kind: 'approval', session_key: 'sess-1', description: 'Run a dangerous shell command', choices: ['once', 'deny'] },
+  };
+  const { payload } = notificationFor(event, preferences);
+  assert.equal(payload.conduit.decision.kind, 'approval');
+  assert.equal(payload.conduit.decision.session_key, 'sess-1');
+  assert.equal(payload.conduit.decision.description, 'Run a dangerous shell command');
+  assert.deepEqual(payload.conduit.decision.choices, ['once', 'deny']);
+  // The expo-notifications `body` mirror must carry the same decision.
+  assert.deepEqual(payload.body.conduit, payload.conduit);
+});
+
+test('notificationFor omits decision when the event has none', () => {
+  const event = { eventId: 'response:12345678', type: 'response.ready', sessionId: 'sess-1', profile: 'default' };
+  const { payload } = notificationFor(event, preferences);
+  assert.equal(payload.conduit.decision, undefined);
+  assert.equal(payload.body.conduit.decision, undefined);
+});
+
+test('notificationFor drops a malformed decision so the notification degrades to a routing stub', () => {
+  const event = {
+    eventId: 'approval:12345678',
+    type: 'approval.needed',
+    sessionId: 'sess-1',
+    profile: 'default',
+    decision: { kind: 'approval', description: 'no session key' }, // not answerable
+  };
+  const { payload } = notificationFor(event, preferences);
+  assert.equal(payload.conduit.decision, undefined);
+});
+
+test('validateEvent passes through a bounded decision', () => {
+  const event = validateEvent({
+    type: 'approval.needed',
+    event_id: 'approval:12345678',
+    session_id: 'sess-1',
+    decision: { kind: 'approval', session_key: 'sess-1', description: 'd'.repeat(900), choices: ['once', 'deny', 'x'.repeat(200)] },
+  });
+  assert.equal(event.decision.kind, 'approval');
+  assert.equal(event.decision.session_key, 'sess-1');
+  assert.equal(event.decision.description.length, 500);
+  assert.equal(event.decision.choices.length, 3); // all retained, each bounded
+  assert.ok(event.decision.choices.every((c) => c.length <= 80));
+});
+
+test('validateDecision rejects unknown kinds and non-answerable payloads', () => {
+  assert.equal(validateDecision(undefined), undefined);
+  assert.equal(validateDecision({ kind: 'sudo', description: 'x', session_key: 's' }), undefined);
+  assert.equal(validateDecision({ kind: 'approval', description: 'x' }), undefined); // no session_key
+  assert.equal(validateDecision({ kind: 'clarify', question: 'q' }), undefined); // no request_id
+  assert.equal(validateDecision({ kind: 'approval', session_key: 's', description: 'd', command: 'secret' }).command, undefined, 'unknown fields are not echoed');
+});

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -105,11 +105,12 @@ def test_sanitize_decision_does_not_coerce_none_into_strings():
     assert decision["choices"] == ["once", "deny"]
 
 
-def test_push_event_binds_decision_kind_to_event_type():
+def test_push_event_only_attaches_approval_decisions_on_approval_events():
+    # Only the approval contract ships; clarify is not answerable from a
+    # payload and the relay rejects it, so it is never emitted or accepted.
     clarify_decision = {"kind": "clarify", "request_id": "r1", "question": "Which?", "choices": ["a"]}
     approval_decision = {"kind": "approval", "session_key": "s", "description": "d", "choices": ["once"]}
 
-    # A clarify decision can never ride an approval event (or vice versa).
     event = push_event(
         "approval.needed",
         identifier="approval:12345678",
@@ -125,3 +126,10 @@ def test_push_event_binds_decision_kind_to_event_type():
         decision=approval_decision,
     )
     assert "decision" not in event
+
+
+def test_sanitize_decision_requires_choices_and_mirrors_relay_contract():
+    # The relay enforces session_key + description + non-empty whitelisted
+    # choices; mirror that here so plugin-side tests describe the real contract.
+    assert sanitize_decision({"kind": "approval", "session_key": "s", "description": "d"}) == {}
+    assert sanitize_decision({"kind": "approval", "session_key": "s", "description": "d", "choices": ["  "]}) == {}

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from events import clarification_text, event_id, is_silent_response, push_event
+from events import approval_decision, clarification_text, event_id, is_silent_response, push_event, sanitize_decision
 
 
 def test_event_identifiers_are_stable_for_replayed_hooks():
@@ -35,3 +35,58 @@ def test_silent_response_matches_only_the_exact_sentinel():
     assert not is_silent_response("Response: [Silent]")
     assert not is_silent_response("")
     assert not is_silent_response(None)
+
+
+def test_push_event_attaches_sanitized_approval_decision():
+    event = push_event(
+        "approval.needed",
+        identifier="approval:12345678",
+        session_id="sess-1",
+        profile="default",
+        body="Hermes is waiting for your approval.",
+        decision=approval_decision(session_key="sess-1", description="Run a dangerous shell command"),
+    )
+    decision = event["decision"]
+    assert decision["kind"] == "approval"
+    assert decision["session_key"] == "sess-1"
+    assert decision["description"] == "Run a dangerous shell command"
+    # once/deny are always-valid server-side; raw command is intentionally absent
+    assert decision["choices"] == ["once", "deny"]
+    assert "command" not in decision
+
+
+def test_push_event_omits_decision_when_session_key_missing():
+    event = push_event(
+        "approval.needed",
+        identifier="approval:12345678",
+        session_id="",
+        decision=approval_decision(session_key="", description="something"),
+    )
+    # No session_key → not answerable → degrade to the plain routing stub.
+    assert "decision" not in event
+
+
+def test_push_event_omits_decision_for_non_decision_events():
+    event = push_event(
+        "response.ready",
+        identifier="response:12345678",
+        session_id="sess-1",
+        decision={"kind": "approval", "description": "x", "session_key": "sess-1"},
+    )
+    assert "decision" not in event
+
+
+def test_sanitize_decision_rejects_unknown_kind_and_oversized_fields():
+    assert sanitize_decision({"kind": "sudo", "description": "x"}) == {}
+    decision = sanitize_decision({
+        "kind": "approval",
+        "description": "d" * 900,
+        "session_key": "k",
+        "choices": ["once", "deny", "a" * 200, "", "b"],
+        "command": "secret",
+    })
+    assert decision["kind"] == "approval"
+    assert len(decision["description"]) == 500
+    assert len(decision["choices"]) == 4  # empties dropped, all retained within cap
+    assert all(len(c) <= 80 for c in decision["choices"])
+    assert "command" not in decision  # unknown fields are not echoed

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -90,3 +90,38 @@ def test_sanitize_decision_rejects_unknown_kind_and_oversized_fields():
     assert len(decision["choices"]) == 4  # empties dropped, all retained within cap
     assert all(len(c) <= 80 for c in decision["choices"])
     assert "command" not in decision  # unknown fields are not echoed
+
+
+def test_sanitize_decision_does_not_coerce_none_into_strings():
+    # A None session_key must be rejected (not become the truthy "None"), and
+    # a None choice entry must be dropped rather than stringified.
+    assert sanitize_decision({"kind": "approval", "session_key": None, "description": "x"}) == {}
+    decision = sanitize_decision({
+        "kind": "approval",
+        "session_key": "s",
+        "description": "x",
+        "choices": ["once", None, "deny"],
+    })
+    assert decision["choices"] == ["once", "deny"]
+
+
+def test_push_event_binds_decision_kind_to_event_type():
+    clarify_decision = {"kind": "clarify", "request_id": "r1", "question": "Which?", "choices": ["a"]}
+    approval_decision = {"kind": "approval", "session_key": "s", "description": "d", "choices": ["once"]}
+
+    # A clarify decision can never ride an approval event (or vice versa).
+    event = push_event(
+        "approval.needed",
+        identifier="approval:12345678",
+        session_id="s",
+        decision=clarify_decision,
+    )
+    assert "decision" not in event
+
+    event = push_event(
+        "input.needed",
+        identifier="input:12345678",
+        session_id="s",
+        decision=approval_decision,
+    )
+    assert "decision" not in event


### PR DESCRIPTION
## Summary

- Approval notifications now carry a structured `decision` object (`kind`/`session_key`/`description`/`choices`), and the relay forwards it into the APNs `conduit` payload (both the top-level and `body` mirrors).
- Lets the Conduit iOS app render an **answerable approval card directly from the push payload** when the decision was raised while the app was backgrounded.
- Adds relay unit tests (`relay/test/`) — the relay's pure notification builders are now importable via an `isMain` startup guard.

## Root cause

When Hermes raises an approval while the Conduit app is backgrounded, the app misses the one-shot `approval.request` gateway stream event, and Hermes exposes no way to recover the decision later — no replay on reconnect, no fetch RPC, and `session.resume` returns only the stored transcript. So tapping the notification opened a session with no card. Routing the card **content** alongside the existing notification pipeline is the only plugin-reachable source for it.

## Changes

- `events.py`: `push_event` accepts an optional `decision` (decision event types only); `approval_decision` builds the approval payload; `sanitize_decision` bounds/whitelists it and requires an answerability key (`session_key` for approval, `request_id` for clarify).
- `__init__.py`: `_pre_approval_request` attaches the decision when the hook provides a `session_key`.
- `relay/src/server.mjs`: `validateEvent`/`validateDecision` re-validate at the trust boundary; `notificationFor` forwards the decision into both `conduit` payload paths; server startup moved behind an `isMain` guard so the module can be imported by tests without binding a port.

## Deliberate tradeoffs (flagged for review)

- **Raw `command` is omitted** from the payload — it can carry secrets, and the relay/APNs path is an extra egress transport. The notification/`description` is what the plugin already sends today. The foreground card still shows the full command.
- **Choices are the always-valid `["once","deny"]` subset** — the `pre_approval_request` hook does not expose `allow_session`/`allow_permanent`, and `once`/`deny` are accepted for every server-side `ApprovalRequest`.
- **Clarify is intentionally not emitted yet**: `clarify.respond` is request-id-only and that id is minted inside the gateway (`_block`), so a clarify card is not answerable from a push payload. Follow-up phases are tracked in the Conduit-side design doc (`docs/superpowers/specs/2026-08-13-decision-cards-after-background-arrival-design.md` on the Conduit PR).

## Validation

- Plugin tests (`tests/test_events.py`): 8 passed, 0 failed (4 new).
- Relay tests (`relay/test/server.test.mjs`, `node --test`): 5 passed, 0 failed.
- `node --check relay/src/server.mjs` clean; `git diff --check` clean.
- Companion iOS PR: kaishi00/hermes-conduit `fix/decision-cards-after-background-arrival` (parses `decision`, caches the card, restores it on resume).