### PR TITLE
Answerable clarify cards via a plugin-owned relay loop

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -6,6 +6,7 @@ import threading
 import uuid
 from typing import Any
 
+from . import clarify_loop
 from .client import enqueue
 from .events import approval_decision, clarification_text, event_id, is_silent_response, push_event
 
@@ -13,6 +14,7 @@ from .events import approval_decision, clarification_text, event_id, is_silent_r
 _child_sessions: set[str] = set()
 _children_lock = threading.Lock()
 _profile = "default"
+_clarify_loop_active = False
 
 
 def register(ctx: Any) -> None:
@@ -24,6 +26,14 @@ def register(ctx: Any) -> None:
     ctx.register_hook("pre_approval_request", _pre_approval_request)
     ctx.register_hook("subagent_start", _subagent_start)
     ctx.register_hook("subagent_stop", _subagent_stop)
+    # Wrap clarify execution so a backgrounded device gets an answerable card
+    # (plugin-minted id, answered through the relay). Older gateways without
+    # middleware support simply keep the original clarify path.
+    if hasattr(ctx, "register_middleware"):
+        ctx.register_middleware("tool_execution", clarify_loop.middleware)
+        clarify_loop.set_profile(_profile)
+        global _clarify_loop_active
+        _clarify_loop_active = True
     from .cli import dispatch, register_cli
     ctx.register_cli_command(
         name="conduit-push",
@@ -36,6 +46,10 @@ def register(ctx: Any) -> None:
 
 def _pre_tool_call(**kwargs: Any) -> None:
     if kwargs.get("tool_name") != "clarify" or _is_child(kwargs.get("session_id")):
+        return
+    if _clarify_loop_active:
+        # The middleware wraps the execution and pushes a richer, answerable
+        # input.needed event itself; pushing here too would double-notify.
         return
     enqueue(push_event(
         "input.needed",

--- a/__init__.py
+++ b/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import functools
 import threading
 import uuid
 from typing import Any
@@ -30,7 +31,10 @@ def register(ctx: Any) -> None:
     # (plugin-minted id, answered through the relay). Older gateways without
     # middleware support simply keep the original clarify path.
     if hasattr(ctx, "register_middleware"):
-        ctx.register_middleware("tool_execution", clarify_loop.middleware)
+        ctx.register_middleware(
+            "tool_execution",
+            functools.partial(clarify_loop.middleware, is_child_session=_is_child),
+        )
         clarify_loop.set_profile(_profile)
         global _clarify_loop_active
         _clarify_loop_active = True

--- a/clarify_loop.py
+++ b/clarify_loop.py
@@ -32,6 +32,11 @@ logger = logging.getLogger("hermes.plugins.conduit_push")
 
 REQUEST_ID_PREFIX = "conduit-push-"
 POLL_INTERVAL_SECONDS = 2.0
+# Consecutive unknown polls tolerated while the event POST and the first poll
+# race (enqueue is async, delivery can lag). Past this the decision was never
+# parked — the push was dropped at enqueue or delivery — and polling can never
+# succeed, so fall back to the original path instead of polling the full budget.
+UNKNOWN_POLL_GRACE = 30  # ~60s at the default interval
 # Hard cap on polling even when the gateway configures an unlimited clarify
 # timeout; the relay expires pending decisions at 2h, and polling stops on
 # the unknown-after-pending transition well before this in practice.
@@ -127,6 +132,7 @@ def _first_answer_wins(
 
     deadline = time.monotonic() + _clarify_poll_budget()
     saw_pending = False
+    consecutive_unknown = 0
     while time.monotonic() < deadline:
         if "original" in outcome or "original_error" in outcome:
             if "original_error" in outcome:
@@ -146,12 +152,22 @@ def _first_answer_wins(
             )
         if state == "pending":
             saw_pending = True
-        elif saw_pending:
-            # unknown-after-pending: the relay expired the decision (2h TTL,
-            # far under an unlimited clarify timeout). Stop polling and let
-            # the original path's own timeout conclude the race instead of
-            # hammering a request that can never succeed.
-            break
+            consecutive_unknown = 0
+            if status.get("deliverable") is False:
+                # Parked but no card was shown (device preferences disabled
+                # this notification): nobody can answer by id. Stop polling
+                # and let the original path's timeout conclude the race.
+                break
+        elif state == "unknown":
+            if saw_pending:
+                # unknown-after-pending: the relay expired the decision (2h
+                # TTL, far under an unlimited clarify timeout).
+                break
+            consecutive_unknown += 1
+            if consecutive_unknown >= UNKNOWN_POLL_GRACE:
+                # Never parked: the push was dropped at enqueue or delivery
+                # (queue full, relay down), so the poll can never succeed.
+                break
         time.sleep(POLL_INTERVAL_SECONDS)
 
     # Poll budget exhausted (unlimited clarify timeout): fall back to whatever

--- a/clarify_loop.py
+++ b/clarify_loop.py
@@ -26,21 +26,26 @@ import uuid
 from typing import Any, Callable
 
 from . import client
-from .events import clarify_decision, event_id, flatten_choice_labels, push_event
+from .events import clarification_text, clarify_decision, event_id, flatten_choice_labels, push_event
 
 logger = logging.getLogger("hermes.plugins.conduit_push")
 
 REQUEST_ID_PREFIX = "conduit-push-"
 POLL_INTERVAL_SECONDS = 2.0
-# Consecutive unknown polls tolerated while the event POST and the first poll
-# race (enqueue is async, delivery can lag). Past this the decision was never
-# parked — the push was dropped at enqueue or delivery — and polling can never
-# succeed, so fall back to the original path instead of polling the full budget.
-UNKNOWN_POLL_GRACE = 30  # ~60s at the default interval
+# Consecutive unproductive polls (unknown status or transport errors) tolerated
+# while the event POST and the first poll race (enqueue is async, delivery can
+# lag, relays blip). Past this the decision was never parked or the relay is
+# unreachable -- polling can never succeed -- so fall back to the original path
+# instead of polling the full budget.
+UNKNOWN_POLL_GRACE = 30  # ~60s at the base interval
 # Hard cap on polling even when the gateway configures an unlimited clarify
 # timeout; the relay expires pending decisions at 2h, and polling stops on
 # the unknown-after-pending transition well before this in practice.
 MAX_POLL_SECONDS = 24 * 60 * 60.0
+# Unanswered polls back off exponentially (capped) so a parked-but-idle
+# decision costs ~a handful of requests per minute instead of 30+, and a
+# gateway's concurrent loops stay well under the relay's shared poll budget.
+MAX_POLL_BACKOFF_SECONDS = 10.0
 
 # Set by register() so pushes carry the profile the rest of the plugin uses.
 profile = "default"
@@ -68,7 +73,10 @@ def middleware(is_child_session: Callable[[str], bool] | None = None, **kwargs: 
         return kwargs["next_call"](kwargs.get("args") or {})
 
     args = dict(kwargs.get("args") or {})
-    question = str(args.get("question") or "").strip()
+    # clarification_text handles every question arg shape the hook path
+    # supported (question / prompt / message / questions[0]) -- LLMs do
+    # deviate from the clarify schema, and those shapes must still get a card.
+    question = clarification_text(args)
     if not question:
         return kwargs["next_call"](args)
 
@@ -132,7 +140,8 @@ def _first_answer_wins(
 
     deadline = time.monotonic() + _clarify_poll_budget()
     saw_pending = False
-    consecutive_unknown = 0
+    consecutive_unproductive = 0
+    unanswered_polls = 0
     while time.monotonic() < deadline:
         if "original" in outcome or "original_error" in outcome:
             if "original_error" in outcome:
@@ -141,7 +150,10 @@ def _first_answer_wins(
         try:
             status = client.poll_decision(request_id)
         except Exception:
-            status = {"status": "pending"}  # transport hiccup: keep waiting
+            # Transport failure (relay down, DNS, throttled). Counted against
+            # the same grace as unknowns: a persistently unreachable relay
+            # must not disable the never-parked stop and poll the full budget.
+            status = {"status": "__error__"}
         state = str(status.get("status") or "")
         if state == "answered":
             return _format_result(
@@ -151,24 +163,25 @@ def _first_answer_wins(
                 multi_select=multi_select,
             )
         if state == "pending":
+            consecutive_unproductive = 0
             saw_pending = True
-            consecutive_unknown = 0
             if status.get("deliverable") is False:
                 # Parked but no card was shown (device preferences disabled
                 # this notification): nobody can answer by id. Stop polling
                 # and let the original path's timeout conclude the race.
                 break
-        elif state == "unknown":
-            if saw_pending:
-                # unknown-after-pending: the relay expired the decision (2h
-                # TTL, far under an unlimited clarify timeout).
+        elif state == "unknown" and saw_pending:
+            # unknown-after-pending: the relay expired the decision (2h TTL,
+            # far under an unlimited clarify timeout).
+            break
+        else:
+            # Unknown before pending, or a transport failure: tolerated for
+            # the grace window, then treated as never-parked/unreachable.
+            consecutive_unproductive += 1
+            if consecutive_unproductive >= UNKNOWN_POLL_GRACE:
                 break
-            consecutive_unknown += 1
-            if consecutive_unknown >= UNKNOWN_POLL_GRACE:
-                # Never parked: the push was dropped at enqueue or delivery
-                # (queue full, relay down), so the poll can never succeed.
-                break
-        time.sleep(POLL_INTERVAL_SECONDS)
+        unanswered_polls += 1
+        time.sleep(_poll_delay(unanswered_polls))
 
     # Poll budget exhausted (unlimited clarify timeout): fall back to whatever
     # the original path produces, waiting for it if necessary.
@@ -179,6 +192,19 @@ def _first_answer_wins(
     if "original_error" in outcome:
         raise outcome["original_error"]
     return outcome["original"]
+
+
+def _poll_delay(unanswered_polls: int) -> float:
+    """Exponential backoff for unanswered polls, capped.
+
+    A parked-but-idle decision should cost a handful of requests per minute,
+    not 30+, and a gateway's concurrent loops must stay well under the relay's
+    shared per-gateway poll budget. Answers land within one capped interval.
+    """
+    base = POLL_INTERVAL_SECONDS
+    if unanswered_polls <= 1:
+        return base
+    return min(base * (2 ** min(unanswered_polls - 1, 8)), MAX_POLL_BACKOFF_SECONDS)
 
 
 def _clarify_poll_budget() -> float:

--- a/clarify_loop.py
+++ b/clarify_loop.py
@@ -17,12 +17,13 @@ the agent cannot tell the paths apart.
 
 from __future__ import annotations
 
+import contextvars
 import json
 import logging
 import threading
 import time
 import uuid
-from typing import Any
+from typing import Any, Callable
 
 from . import client
 from .events import clarify_decision, event_id, flatten_choice_labels, push_event
@@ -32,7 +33,8 @@ logger = logging.getLogger("hermes.plugins.conduit_push")
 REQUEST_ID_PREFIX = "conduit-push-"
 POLL_INTERVAL_SECONDS = 2.0
 # Hard cap on polling even when the gateway configures an unlimited clarify
-# timeout; the relay expires pending decisions at 2h anyway.
+# timeout; the relay expires pending decisions at 2h, and polling stops on
+# the unknown-after-pending transition well before this in practice.
 MAX_POLL_SECONDS = 24 * 60 * 60.0
 
 # Set by register() so pushes carry the profile the rest of the plugin uses.
@@ -44,13 +46,20 @@ def set_profile(value: str) -> None:
     profile = value or "default"
 
 
-def middleware(**kwargs: Any) -> Any:
-    """``tool_execution`` middleware entry point."""
+def middleware(is_child_session: Callable[[str], bool] | None = None, **kwargs: Any) -> Any:
+    """``tool_execution`` middleware entry point.
+
+    ``is_child_session`` mirrors the hook path's subagent exclusion so a
+    delegated child session's clarify keeps the original path only.
+    """
     tool_name = str(kwargs.get("tool_name") or "")
     if tool_name != "clarify":
         return kwargs["next_call"](kwargs.get("args") or {})
     if not client.load_state():
         # Unpaired profile: no push is possible, keep the original path only.
+        return kwargs["next_call"](kwargs.get("args") or {})
+    session_id = _text(kwargs.get("session_id"))
+    if is_child_session and is_child_session(session_id):
         return kwargs["next_call"](kwargs.get("args") or {})
 
     args = dict(kwargs.get("args") or {})
@@ -65,7 +74,7 @@ def middleware(**kwargs: Any) -> Any:
     client.enqueue(push_event(
         "input.needed",
         identifier=event_id("input", kwargs.get("turn_id"), kwargs.get("tool_call_id"), request_id),
-        session_id=_text(kwargs.get("session_id")),
+        session_id=session_id,
         profile=profile,
         body=question,
         decision=clarify_decision(request_id=request_id, question=question, choices=labels or None),
@@ -99,12 +108,25 @@ def _first_answer_wins(
         except Exception as exc:  # pragma: no cover - mirrors tool error path
             outcome["original_error"] = exc
 
-    # Daemon thread: if the relay answer wins, this thread keeps blocking on
-    # the gateway's own prompt until it is answered or times out; its result
-    # is then discarded. It must never hold up interpreter shutdown.
-    threading.Thread(target=_run_original, name="conduit-push-clarify", daemon=True).start()
+    # Hermes invokes middleware synchronously inline (verified against
+    # hermes_cli.middleware._run_execution_chain: plain calls, no event loop),
+    # so exactly one of the two racing paths must move off-thread — this one.
+    # The gateway's own prompt blocks on a threading.Event, which is
+    # thread-safe, but contextvars do NOT propagate to new threads; run the
+    # body through a copy of the current context so anything the tool path
+    # reads (hook scoping, session context) behaves as if inline.
+    # Daemon: if the relay answer wins, this thread keeps blocking on the
+    # gateway's own prompt until it is answered or times out; its result is
+    # then discarded. It must never hold up interpreter shutdown.
+    threading.Thread(
+        target=contextvars.copy_context().run,
+        args=(_run_original,),
+        name="conduit-push-clarify",
+        daemon=True,
+    ).start()
 
     deadline = time.monotonic() + _clarify_poll_budget()
+    saw_pending = False
     while time.monotonic() < deadline:
         if "original" in outcome or "original_error" in outcome:
             if "original_error" in outcome:
@@ -114,13 +136,22 @@ def _first_answer_wins(
             status = client.poll_decision(request_id)
         except Exception:
             status = {"status": "pending"}  # transport hiccup: keep waiting
-        if status.get("status") == "answered":
+        state = str(status.get("status") or "")
+        if state == "answered":
             return _format_result(
                 question=question,
                 offered=offered,
                 answer=str(status.get("answer") or ""),
                 multi_select=multi_select,
             )
+        if state == "pending":
+            saw_pending = True
+        elif saw_pending:
+            # unknown-after-pending: the relay expired the decision (2h TTL,
+            # far under an unlimited clarify timeout). Stop polling and let
+            # the original path's own timeout conclude the race instead of
+            # hammering a request that can never succeed.
+            break
         time.sleep(POLL_INTERVAL_SECONDS)
 
     # Poll budget exhausted (unlimited clarify timeout): fall back to whatever
@@ -139,12 +170,12 @@ def _clarify_poll_budget() -> float:
     try:
         from tools.clarify_gateway import get_clarify_timeout
 
-        timeout = get_clarify_timeout()
+        timeout = float(get_clarify_timeout())
     except Exception:
-        timeout = 3600
-    if not isinstance(timeout, (int, float)) or timeout <= 0:
+        timeout = 3600.0
+    if timeout <= 0:
         return MAX_POLL_SECONDS
-    return min(float(timeout) + 30.0, MAX_POLL_SECONDS)
+    return min(timeout + 30.0, MAX_POLL_SECONDS)
 
 
 def _format_result(*, question: str, offered: list[str], answer: str, multi_select: bool) -> str:

--- a/clarify_loop.py
+++ b/clarify_loop.py
@@ -1,0 +1,185 @@
+"""Answerable clarify cards for backgrounded Conduit devices.
+
+Hermes mints its clarify request id inside the gateway's blocking prompt,
+where no plugin hook can observe it, so a push alone can never produce an
+answerable clarify card through ``clarify.respond``. This module instead
+wraps clarify execution with ``tool_execution`` middleware:
+
+* mint a plugin-owned id and push the question/choices to the device,
+* run the ORIGINAL tool call on a daemon thread (desktop/CLI answering via
+  the gateway's own ``clarify.request`` is completely unchanged),
+* poll the relay for the device's answer while both wait,
+* first answer wins; the loser resolves into a discarded result.
+
+The tool result is formatted exactly like the built-in ``clarify_tool`` so
+the agent cannot tell the paths apart.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+import uuid
+from typing import Any
+
+from . import client
+from .events import clarify_decision, event_id, flatten_choice_labels, push_event
+
+logger = logging.getLogger("hermes.plugins.conduit_push")
+
+REQUEST_ID_PREFIX = "conduit-push-"
+POLL_INTERVAL_SECONDS = 2.0
+# Hard cap on polling even when the gateway configures an unlimited clarify
+# timeout; the relay expires pending decisions at 2h anyway.
+MAX_POLL_SECONDS = 24 * 60 * 60.0
+
+# Set by register() so pushes carry the profile the rest of the plugin uses.
+profile = "default"
+
+
+def set_profile(value: str) -> None:
+    global profile
+    profile = value or "default"
+
+
+def middleware(**kwargs: Any) -> Any:
+    """``tool_execution`` middleware entry point."""
+    tool_name = str(kwargs.get("tool_name") or "")
+    if tool_name != "clarify":
+        return kwargs["next_call"](kwargs.get("args") or {})
+    if not client.load_state():
+        # Unpaired profile: no push is possible, keep the original path only.
+        return kwargs["next_call"](kwargs.get("args") or {})
+
+    args = dict(kwargs.get("args") or {})
+    question = str(args.get("question") or "").strip()
+    if not question:
+        return kwargs["next_call"](args)
+
+    labels = flatten_choice_labels(args.get("choices"))
+    multi_select = bool(args.get("multi_select"))
+    request_id = f"{REQUEST_ID_PREFIX}{uuid.uuid4().hex[:12]}"
+
+    client.enqueue(push_event(
+        "input.needed",
+        identifier=event_id("input", kwargs.get("turn_id"), kwargs.get("tool_call_id"), request_id),
+        session_id=_text(kwargs.get("session_id")),
+        profile=profile,
+        body=question,
+        decision=clarify_decision(request_id=request_id, question=question, choices=labels or None),
+    ))
+
+    return _first_answer_wins(
+        request_id=request_id,
+        next_call=kwargs["next_call"],
+        args=args,
+        question=question,
+        offered=labels,
+        multi_select=multi_select,
+    )
+
+
+def _first_answer_wins(
+    *,
+    request_id: str,
+    next_call: Any,
+    args: dict[str, Any],
+    question: str,
+    offered: list[str],
+    multi_select: bool,
+) -> Any:
+    """Race the original clarify call against the relay answer poll."""
+    outcome: dict[str, Any] = {}
+
+    def _run_original() -> None:
+        try:
+            outcome["original"] = next_call(args)
+        except Exception as exc:  # pragma: no cover - mirrors tool error path
+            outcome["original_error"] = exc
+
+    # Daemon thread: if the relay answer wins, this thread keeps blocking on
+    # the gateway's own prompt until it is answered or times out; its result
+    # is then discarded. It must never hold up interpreter shutdown.
+    threading.Thread(target=_run_original, name="conduit-push-clarify", daemon=True).start()
+
+    deadline = time.monotonic() + _clarify_poll_budget()
+    while time.monotonic() < deadline:
+        if "original" in outcome or "original_error" in outcome:
+            if "original_error" in outcome:
+                raise outcome["original_error"]
+            return outcome["original"]
+        try:
+            status = client.poll_decision(request_id)
+        except Exception:
+            status = {"status": "pending"}  # transport hiccup: keep waiting
+        if status.get("status") == "answered":
+            return _format_result(
+                question=question,
+                offered=offered,
+                answer=str(status.get("answer") or ""),
+                multi_select=multi_select,
+            )
+        time.sleep(POLL_INTERVAL_SECONDS)
+
+    # Poll budget exhausted (unlimited clarify timeout): fall back to whatever
+    # the original path produces, waiting for it if necessary.
+    if "original_error" in outcome:
+        raise outcome["original_error"]
+    while "original" not in outcome and "original_error" not in outcome:
+        time.sleep(POLL_INTERVAL_SECONDS)
+    if "original_error" in outcome:
+        raise outcome["original_error"]
+    return outcome["original"]
+
+
+def _clarify_poll_budget() -> float:
+    """Match the gateway's configured clarify timeout, capped for safety."""
+    try:
+        from tools.clarify_gateway import get_clarify_timeout
+
+        timeout = get_clarify_timeout()
+    except Exception:
+        timeout = 3600
+    if not isinstance(timeout, (int, float)) or timeout <= 0:
+        return MAX_POLL_SECONDS
+    return min(float(timeout) + 30.0, MAX_POLL_SECONDS)
+
+
+def _format_result(*, question: str, offered: list[str], answer: str, multi_select: bool) -> str:
+    """Build the same JSON the built-in clarify_tool returns for an answer."""
+    from tools.clarify_tool import strip_recommended
+
+    if multi_select and offered:
+        user_response: Any = [strip_recommended(part) for part in _parse_multi_select(answer)]
+    else:
+        user_response = strip_recommended(answer)
+    return json.dumps(
+        {
+            "question": question,
+            "choices_offered": offered,
+            "user_response": user_response,
+        },
+        ensure_ascii=False,
+    )
+
+
+def _parse_multi_select(raw: str) -> list[str]:
+    """Parse a multi-select answer: JSON array or comma-separated labels.
+
+    Local mirror of the built-in tool's parser (a private function there).
+    """
+    text = str(raw).strip()
+    if text.startswith("["):
+        try:
+            parsed = json.loads(text)
+            if isinstance(parsed, list):
+                return [str(part).strip() for part in parsed if str(part).strip()]
+        except json.JSONDecodeError:
+            pass
+    return [part.strip() for part in text.split(",") if part.strip()]
+
+
+def _text(value: Any) -> str:
+    return value.strip() if isinstance(value, str) else ""

--- a/client.py
+++ b/client.py
@@ -109,6 +109,23 @@ def send_now(event: dict[str, Any]) -> dict[str, Any]:
     )
 
 
+def poll_decision(request_id: str) -> dict[str, Any]:
+    """Poll the relay for a push-delivered clarify answer by plugin-minted id.
+
+    Returns {"status": "answered", "answer": str} once the device responded,
+    {"status": "pending"} otherwise. Raises on transport errors so the caller
+    can decide to keep waiting.
+    """
+    state = load_state()
+    if not state:
+        raise RuntimeError("This Hermes profile is not paired with Conduit.")
+    return request_json(
+        f"{state['relay_url'].rstrip('/')}/v1/decisions/{request_id}",
+        method="GET",
+        credential=state["credential"],
+    )
+
+
 def request_json(
     url: str,
     *,

--- a/events.py
+++ b/events.py
@@ -38,12 +38,13 @@ def push_event(
     # `decision` carries the structured card content that lets Conduit render
     # an answerable card from the push payload alone, without the one-shot
     # gateway stream event (which is missed while the app is backgrounded).
-    # Only the approval contract is shipped: clarify is not answerable from a
-    # payload (its request id is minted gateway-side), and the relay rejects
-    # it, so it is not emitted or accepted here until that phase exists.
-    if decision and kind == "approval.needed":
+    # The decision kind must match the event type: approval.needed -> approval
+    # (answered via the gateway's approval.respond), input.needed -> clarify
+    # (answered via the relay's decision loop with a plugin-minted id).
+    if decision and kind in ("approval.needed", "input.needed"):
         sanitized = sanitize_decision(decision)
-        if sanitized:
+        expected_kind = "approval" if kind == "approval.needed" else "clarify"
+        if sanitized and sanitized.get("kind") == expected_kind:
             event["decision"] = sanitized
     return event
 
@@ -67,39 +68,90 @@ def approval_decision(*, session_key: str, description: str) -> dict[str, Any]:
     }
 
 
+def clarify_decision(*, request_id: str, question: str, choices: list[str] | None = None) -> dict[str, Any]:
+    """Build the structured payload for a clarify notification.
+
+    The gateway's own clarify request id is minted inside its blocking prompt
+    and unreachable to plugins, so the middleware mints this id and answers
+    return through the relay's /v1/decisions endpoints while the original
+    clarify callback keeps serving desktop/CLI clients.
+    """
+    decision: dict[str, Any] = {"kind": "clarify", "request_id": request_id, "question": question}
+    if choices:
+        decision["choices"] = choices
+    return decision
+
+
+def flatten_choice_labels(choices: Any) -> list[str]:
+    """Flatten clarify tool choices to display labels.
+
+    Mirrors tools.clarify_tool._flatten_choice: bare strings pass through and
+    LLM-emitted dict shapes unwrap via their canonical user-facing keys.
+    """
+    if not isinstance(choices, list):
+        return []
+    labels: list[str] = []
+    for choice in choices:
+        label = ""
+        if isinstance(choice, str):
+            label = choice.strip()
+        elif isinstance(choice, dict):
+            for key in ("label", "description", "text", "title"):
+                value = choice.get(key)
+                if isinstance(value, str) and value.strip():
+                    label = value.strip()
+                    break
+        if label:
+            labels.append(label)
+    return labels[:8]
+
+
 def sanitize_decision(decision: dict[str, Any]) -> dict[str, Any]:
     """Bound and whitelist a decision payload before it leaves the gateway.
 
     Defense in depth: the relay re-validates, but keep this side bounded too
     so a malformed hook payload can never push an oversized or unknown-shaped
-    object through to the relay/APNs. Mirrors the relay's contract: approval
-    only (clarify is rejected there until it is answerable from a payload),
-    requiring the session key that routes the answer and the description that
-    renders the card.
+    object through to the relay/APNs. Mirrors the relay's contract:
+    approval requires the session key that routes the answer, the description
+    that renders the card, and non-empty whitelisted choices; clarify
+    requires the plugin-minted request id and the question.
     """
     if not isinstance(decision, dict):
         return {}
-    if _clean(decision.get("kind", ""), 40) != "approval":
-        return {}
-    sanitized: dict[str, Any] = {"kind": "approval"}
-    for key in ("session_key", "description"):
-        value = _clean(decision.get(key, ""), 500)
-        if value:
-            sanitized[key] = value
-    choices = decision.get("choices")
-    if isinstance(choices, list):
-        # Clean first, then drop empties: filtering on the raw value would
-        # coerce None to the truthy "None" and forward it as a choice.
-        cleaned = [value for value in (_clean(choice, 80) for choice in choices) if value]
-        if cleaned:
-            sanitized["choices"] = cleaned[:8]
-    # Require both something to display, the key needed to answer it, and at
-    # least one usable choice — the same shape the relay enforces.
-    if not sanitized.get("description") or not sanitized.get("session_key"):
-        return {}
-    if not sanitized.get("choices"):
-        return {}
-    return sanitized
+    kind = _clean(decision.get("kind", ""), 40)
+    if kind == "approval":
+        sanitized: dict[str, Any] = {"kind": "approval"}
+        for key in ("session_key", "description"):
+            value = _clean(decision.get(key, ""), 500)
+            if value:
+                sanitized[key] = value
+        choices = decision.get("choices")
+        if isinstance(choices, list):
+            # Clean first, then drop empties: filtering on the raw value would
+            # coerce None to the truthy "None" and forward it as a choice.
+            cleaned = [value for value in (_clean(choice, 80) for choice in choices) if value]
+            if cleaned:
+                sanitized["choices"] = cleaned[:8]
+        if not sanitized.get("description") or not sanitized.get("session_key"):
+            return {}
+        if not sanitized.get("choices"):
+            return {}
+        return sanitized
+    if kind == "clarify":
+        sanitized = {"kind": "clarify"}
+        for key in ("request_id", "question"):
+            value = _clean(decision.get(key, ""), 500)
+            if value:
+                sanitized[key] = value
+        choices = decision.get("choices")
+        if isinstance(choices, list):
+            cleaned = [value for value in (_clean(choice, 80) for choice in choices) if value]
+            if cleaned:
+                sanitized["choices"] = cleaned[:8]
+        if not sanitized.get("request_id") or not sanitized.get("question"):
+            return {}
+        return sanitized
+    return {}
 
 
 def clarification_text(args: Any) -> str:

--- a/relay/src/server.mjs
+++ b/relay/src/server.mjs
@@ -384,11 +384,16 @@ function sendJson(response, status, body) {
   response.end(encoded);
 }
 
+let lastLimitsSweepAt = 0;
+
 function enforceRateLimit(key, maximum, windowMs) {
   const now = Date.now();
   // The map never evicts on its own and some keys (per-IP buckets) are
-  // attacker-rotatable, so sweep expired entries once it grows large.
-  if (limits.size > 10_000) {
+  // attacker-rotatable. Sweep expired entries once it grows large, but at
+  // most once per 30s so a sustained flood cannot turn every request into a
+  // full-map scan.
+  if (limits.size > 10_000 && now - lastLimitsSweepAt > 30_000) {
+    lastLimitsSweepAt = now;
     for (const [limitKey, limit] of limits) {
       if (limit.resetAt <= now) limits.delete(limitKey);
     }

--- a/relay/src/server.mjs
+++ b/relay/src/server.mjs
@@ -134,6 +134,19 @@ async function route(request, response) {
     enforceRateLimit(`event:${installation.id}`, 30, 60_000);
     const body = await readJson(request);
     const event = validateEvent(body);
+    // A clarify decision carries a plugin-minted request id; park it so the
+    // device can answer by id and the gateway can poll for the answer while
+    // its middleware blocks the tool call. Saved regardless of delivery
+    // preferences so poll semantics stay a simple answered|pending|unknown.
+    if (event.decision?.kind === 'clarify' && event.decision.request_id) {
+      store.savePendingDecision({
+        id: event.decision.request_id,
+        installationId: installation.id,
+        gatewayId: credential.gatewayId,
+        question: event.decision.question,
+        choices: event.decision.choices,
+      });
+    }
     if (!store.acceptEvent(installation.id, event.eventId)) return sendJson(response, 200, { accepted: true, duplicate: true });
     if (!shouldDeliver(installation.preferences, event.type)) return sendJson(response, 202, { accepted: true, delivered: false });
     const notification = notificationFor(event, installation.preferences);
@@ -141,6 +154,33 @@ async function route(request, response) {
     if (result.status === 410 || result.reason === 'BadDeviceToken' || result.reason === 'Unregistered') store.deactivateInstallation(installation.id);
     if (!result.ok) return sendJson(response, 502, { error: 'apns_rejected', reason: result.reason, status: result.status });
     return sendJson(response, 202, { accepted: true, delivered: true });
+  }
+
+  // ── Clarify answer loop ──────────────────────────────────────────────
+  const decisionMatch = url.pathname.match(/^\/v1\/decisions\/([A-Za-z0-9_-]{4,128})$/);
+  if (decisionMatch && request.method === 'POST') {
+    // The device that received the push answers by the plugin-minted id.
+    const id = decisionMatch[1];
+    const body = await readJson(request);
+    const answer = cleanText(body.answer, 2000);
+    if (!answer) return sendJson(response, 400, { error: 'invalid_answer' });
+    const credential = bearerCredential(request);
+    if (!credential) return sendJson(response, 401, { error: 'unauthorized' });
+    const installation = store.authenticate(credential.id, credential.secret, 'device');
+    if (!installation) return sendJson(response, 401, { error: 'unauthorized' });
+    enforceRateLimit(`decision-respond:${installation.id}`, 30, 60_000);
+    const outcome = store.respondPendingDecision(installation.id, id, answer);
+    if (outcome === 'unknown') return sendJson(response, 404, { error: 'unknown_decision' });
+    if (outcome === 'already_answered') return sendJson(response, 409, { error: 'already_answered' });
+    return sendJson(response, 200, { status: 'answered' });
+  }
+  if (decisionMatch && request.method === 'GET') {
+    // The gateway polls for the answer while its clarify middleware blocks.
+    const credential = gatewayCredential(request);
+    if (!credential || !store.authenticateGateway(credential.installationId, credential.gatewayId, credential.secret)) return sendJson(response, 401, { error: 'unauthorized' });
+    enforceRateLimit(`decision-poll:${credential.gatewayId}`, 120, 60_000);
+    const status = store.pendingDecisionStatus(credential.installationId, credential.gatewayId, decisionMatch[1]);
+    return sendJson(response, 200, status);
   }
 
   if (request.method === 'DELETE' && url.pathname === '/v1/gateways/current') {
@@ -261,27 +301,42 @@ function validateEvent(body) {
 }
 
 // Mirror the plugin's decision sanitization at the relay trust boundary.
-// Only the approval contract is shipped: a clarify decision cannot be answered
-// from the payload (its request id is minted gateway-side), so it is rejected
-// until that phase exists, and the kind must agree with the event type.
-// Choices are whitelisted to the gateway's approval vocabulary so a
-// compromised gateway cannot inject arbitrary button text into the payload.
+// Two contracts, each bound to its event type:
+// - approval: session-keyed, answered via the gateway's approval.respond;
+//   choices whitelisted to the gateway's approval vocabulary.
+// - clarify: keyed by a plugin-minted request id (the gateway's own clarify
+//   id is unreachable to plugins), answered via this relay's /v1/decisions
+//   endpoints. Choices are model-generated labels, so they are bounded but
+//   deliberately not vocabulary-whitelisted.
 // Anything malformed degrades to undefined and the notification ships as a
 // routing stub.
 function validateDecision(value, eventType) {
   if (!value || typeof value !== 'object') return undefined;
-  if (cleanText(value.kind, 40) !== 'approval' || eventType !== 'approval.needed') return undefined;
-  const sessionKey = cleanIdentifier(value.session_key, 180);
-  const description = cleanText(value.description, 500);
-  if (!sessionKey || !description) return undefined;
-  const allowed = new Set(['once', 'session', 'always', 'deny']);
-  const choices = [...new Set(
-    (Array.isArray(value.choices) ? value.choices : [])
+  const kind = cleanText(value.kind, 40);
+  if (kind === 'approval' && eventType === 'approval.needed') {
+    const sessionKey = cleanIdentifier(value.session_key, 180);
+    const description = cleanText(value.description, 500);
+    if (!sessionKey || !description) return undefined;
+    const allowed = new Set(['once', 'session', 'always', 'deny']);
+    const choices = [...new Set(
+      (Array.isArray(value.choices) ? value.choices : [])
+        .map((choice) => cleanText(choice, 80))
+        .filter((choice) => allowed.has(choice)),
+    )];
+    if (!choices.length) return undefined;
+    return { kind: 'approval', session_key: sessionKey, description, choices };
+  }
+  if (kind === 'clarify' && eventType === 'input.needed') {
+    const requestId = cleanIdentifier(value.request_id, 128);
+    const question = cleanText(value.question, 500);
+    if (!requestId || !question) return undefined;
+    const choices = (Array.isArray(value.choices) ? value.choices : [])
       .map((choice) => cleanText(choice, 80))
-      .filter((choice) => allowed.has(choice)),
-  )];
-  if (!choices.length) return undefined;
-  return { kind: 'approval', session_key: sessionKey, description, choices };
+      .filter((choice) => choice !== undefined)
+      .slice(0, 8);
+    return { kind: 'clarify', request_id: requestId, question, ...(choices.length ? { choices } : {}) };
+  }
+  return undefined;
 }
 
 function validateDeviceToken(value) {

--- a/relay/src/server.mjs
+++ b/relay/src/server.mjs
@@ -139,7 +139,9 @@ async function route(request, response) {
     // device can answer by id and the gateway can poll for the answer while
     // its middleware blocks the tool call. Saved after the dedupe check so a
     // re-delivered event can never overwrite (and wipe the answer of) the
-    // already-parked decision.
+    // already-parked decision. `deliverable` records whether device
+    // preferences will actually show an answerable card, so the plugin can
+    // stop polling a decision nobody can answer.
     if (event.decision?.kind === 'clarify' && event.decision.request_id) {
       store.savePendingDecision({
         id: event.decision.request_id,
@@ -147,6 +149,8 @@ async function route(request, response) {
         gatewayId: credential.gatewayId,
         question: event.decision.question,
         choices: event.decision.choices,
+        deliverable: shouldDeliver(installation.preferences, event.type)
+          && installation.preferences.decision_cards !== false,
       });
     }
     if (!shouldDeliver(installation.preferences, event.type)) return sendJson(response, 202, { accepted: true, delivered: false });
@@ -382,6 +386,13 @@ function sendJson(response, status, body) {
 
 function enforceRateLimit(key, maximum, windowMs) {
   const now = Date.now();
+  // The map never evicts on its own and some keys (per-IP buckets) are
+  // attacker-rotatable, so sweep expired entries once it grows large.
+  if (limits.size > 10_000) {
+    for (const [limitKey, limit] of limits) {
+      if (limit.resetAt <= now) limits.delete(limitKey);
+    }
+  }
   const value = limits.get(key);
   if (!value || value.resetAt <= now) { limits.set(key, { count: 1, resetAt: now + windowMs }); return; }
   value.count += 1;

--- a/relay/src/server.mjs
+++ b/relay/src/server.mjs
@@ -134,10 +134,12 @@ async function route(request, response) {
     enforceRateLimit(`event:${installation.id}`, 30, 60_000);
     const body = await readJson(request);
     const event = validateEvent(body);
+    if (!store.acceptEvent(installation.id, event.eventId)) return sendJson(response, 200, { accepted: true, duplicate: true });
     // A clarify decision carries a plugin-minted request id; park it so the
     // device can answer by id and the gateway can poll for the answer while
-    // its middleware blocks the tool call. Saved regardless of delivery
-    // preferences so poll semantics stay a simple answered|pending|unknown.
+    // its middleware blocks the tool call. Saved after the dedupe check so a
+    // re-delivered event can never overwrite (and wipe the answer of) the
+    // already-parked decision.
     if (event.decision?.kind === 'clarify' && event.decision.request_id) {
       store.savePendingDecision({
         id: event.decision.request_id,
@@ -147,7 +149,6 @@ async function route(request, response) {
         choices: event.decision.choices,
       });
     }
-    if (!store.acceptEvent(installation.id, event.eventId)) return sendJson(response, 200, { accepted: true, duplicate: true });
     if (!shouldDeliver(installation.preferences, event.type)) return sendJson(response, 202, { accepted: true, delivered: false });
     const notification = notificationFor(event, installation.preferences);
     const result = await apns.send(installation.deviceToken, notification);
@@ -160,15 +161,19 @@ async function route(request, response) {
   const decisionMatch = url.pathname.match(/^\/v1\/decisions\/([A-Za-z0-9_-]{4,128})$/);
   if (decisionMatch && request.method === 'POST') {
     // The device that received the push answers by the plugin-minted id.
+    // Authenticate and rate-limit before reading the body: this endpoint is
+    // publicly reachable, and unauthenticated request bodies must never be
+    // parsed (matches the pre-auth posture of /v1/pairings/claim).
     const id = decisionMatch[1];
-    const body = await readJson(request);
-    const answer = cleanText(body.answer, 2000);
-    if (!answer) return sendJson(response, 400, { error: 'invalid_answer' });
+    enforceRateLimit(`decision-respond-ip:${client}`, 60, 60_000);
     const credential = bearerCredential(request);
     if (!credential) return sendJson(response, 401, { error: 'unauthorized' });
     const installation = store.authenticate(credential.id, credential.secret, 'device');
     if (!installation) return sendJson(response, 401, { error: 'unauthorized' });
     enforceRateLimit(`decision-respond:${installation.id}`, 30, 60_000);
+    const body = await readJson(request);
+    const answer = cleanText(body.answer, 2000);
+    if (!answer) return sendJson(response, 400, { error: 'invalid_answer' });
     const outcome = store.respondPendingDecision(installation.id, id, answer);
     if (outcome === 'unknown') return sendJson(response, 404, { error: 'unknown_decision' });
     if (outcome === 'already_answered') return sendJson(response, 409, { error: 'already_answered' });

--- a/relay/src/store.mjs
+++ b/relay/src/store.mjs
@@ -151,6 +151,10 @@ export class RelayStore {
 
   savePendingDecision({ id, installationId, gatewayId, question, choices, deliverable = true }) {
     this.prune();
+    // uuid4-minted ids make collisions vanishingly unlikely, but never let a
+    // same-id write from another installation clobber a parked decision.
+    const existing = this.data.pendingDecisions[id];
+    if (existing && existing.installationId !== installationId) return;
     this.data.pendingDecisions[id] = {
       installationId,
       gatewayId,

--- a/relay/src/store.mjs
+++ b/relay/src/store.mjs
@@ -149,13 +149,16 @@ export class RelayStore {
   // middleware blocks the tool call. Approval decisions answer via the
   // gateway directly and never enter this store.
 
-  savePendingDecision({ id, installationId, gatewayId, question, choices }) {
+  savePendingDecision({ id, installationId, gatewayId, question, choices, deliverable = true }) {
     this.prune();
     this.data.pendingDecisions[id] = {
       installationId,
       gatewayId,
       question: String(question ?? ''),
       choices: Array.isArray(choices) ? choices.map(String) : [],
+      // False when device preferences mean no card was shown; the gateway's
+      // poller stops early instead of polling a decision nobody can answer.
+      deliverable: Boolean(deliverable),
       createdAt: Date.now(),
     };
     const entries = Object.entries(this.data.pendingDecisions);
@@ -184,7 +187,11 @@ export class RelayStore {
     if (!decision || decision.installationId !== installationId || decision.gatewayId !== gatewayId) {
       return { status: 'unknown' };
     }
-    if (decision.answer === undefined) return { status: 'pending' };
+    if (decision.answer === undefined) {
+      // Legacy records predate the flag; treat missing as deliverable so the
+      // poller's behavior is unchanged for decisions parked by older relays.
+      return { status: 'pending', deliverable: decision.deliverable !== false };
+    }
     return { status: 'answered', answer: decision.answer };
   }
 

--- a/relay/src/store.mjs
+++ b/relay/src/store.mjs
@@ -21,7 +21,7 @@ const defaultPreferences = Object.freeze({
 export class RelayStore {
   constructor(path) {
     this.path = path;
-    this.data = { version: 1, installations: {}, pairings: {}, eventIds: {} };
+    this.data = { version: 1, installations: {}, pairings: {}, eventIds: {}, pendingDecisions: {} };
     this.load();
   }
 
@@ -29,7 +29,7 @@ export class RelayStore {
     if (!existsSync(this.path)) return;
     const parsed = JSON.parse(readFileSync(this.path, 'utf8'));
     if (parsed?.version !== 1 || typeof parsed.installations !== 'object') throw new Error('Unsupported relay data format.');
-    this.data = { version: 1, installations: parsed.installations ?? {}, pairings: parsed.pairings ?? {}, eventIds: parsed.eventIds ?? {} };
+    this.data = { version: 1, installations: parsed.installations ?? {}, pairings: parsed.pairings ?? {}, eventIds: parsed.eventIds ?? {}, pendingDecisions: parsed.pendingDecisions ?? {} };
     this.prune();
   }
 
@@ -142,6 +142,52 @@ export class RelayStore {
     return true;
   }
 
+  // ── Pending decisions (clarify answer loop) ─────────────────────────
+  // A clarify decision the plugin pushes carries a plugin-minted request id
+  // because the gateway's own clarify id is unreachable to plugins. The
+  // device answers by that id; the plugin polls for the answer while its
+  // middleware blocks the tool call. Approval decisions answer via the
+  // gateway directly and never enter this store.
+
+  savePendingDecision({ id, installationId, gatewayId, question, choices }) {
+    this.prune();
+    this.data.pendingDecisions[id] = {
+      installationId,
+      gatewayId,
+      question: String(question ?? ''),
+      choices: Array.isArray(choices) ? choices.map(String) : [],
+      createdAt: Date.now(),
+    };
+    const entries = Object.entries(this.data.pendingDecisions);
+    if (entries.length > 256) {
+      for (const [key] of entries.sort((a, b) => a[1].createdAt - b[1].createdAt).slice(0, entries.length - 256)) {
+        delete this.data.pendingDecisions[key];
+      }
+    }
+    this.save();
+  }
+
+  respondPendingDecision(installationId, id, answer) {
+    this.prune();
+    const decision = this.data.pendingDecisions[id];
+    if (!decision || decision.installationId !== installationId) return 'unknown';
+    if (decision.answer !== undefined) return 'already_answered';
+    decision.answer = String(answer ?? '').slice(0, 2000);
+    decision.answeredAt = Date.now();
+    this.save();
+    return 'answered';
+  }
+
+  pendingDecisionStatus(installationId, gatewayId, id) {
+    this.prune();
+    const decision = this.data.pendingDecisions[id];
+    if (!decision || decision.installationId !== installationId || decision.gatewayId !== gatewayId) {
+      return { status: 'unknown' };
+    }
+    if (decision.answer === undefined) return { status: 'pending' };
+    return { status: 'answered', answer: decision.answer };
+  }
+
   prune() {
     const now = Date.now();
     for (const [key, pairing] of Object.entries(this.data.pairings)) {
@@ -149,6 +195,12 @@ export class RelayStore {
     }
     for (const [key, timestamp] of Object.entries(this.data.eventIds)) {
       if (Number(timestamp) < now - 24 * 60 * 60_000) delete this.data.eventIds[key];
+    }
+    // Clarify prompts live at most ~1h server-side (agent.clarify_timeout
+    // default 3600s); 2h covers drift and unlimited-config edge cases while
+    // still bounding the store.
+    for (const [key, decision] of Object.entries(this.data.pendingDecisions ?? {})) {
+      if (Number(decision.createdAt) < now - 2 * 60 * 60_000) delete this.data.pendingDecisions[key];
     }
   }
 }

--- a/relay/test/decisions.e2e.test.mjs
+++ b/relay/test/decisions.e2e.test.mjs
@@ -168,6 +168,29 @@ test('clarify decision: push → device answer → gateway poll', async () => {
   });
   assert.equal(reanswer.status, 409);
 
+  // A duplicate delivery of the same event (same event_id) must not wipe the
+  // parked decision's answer: dedupe happens before the pending-decision save.
+  const duplicate = await api('/v1/events', {
+    method: 'POST',
+    credential: gatewayCredential,
+    body: {
+      type: 'input.needed',
+      event_id: 'input:abcdef123456',
+      session_id: 'sess-1',
+      profile: 'default',
+      decision: {
+        kind: 'clarify',
+        request_id: 'conduit-push-abc123',
+        question: 'Which color?',
+        choices: ['Red', 'Blue'],
+      },
+    },
+  });
+  assert.equal(duplicate.status, 200);
+  assert.equal(duplicate.json.duplicate, true);
+  const afterDuplicate = await api('/v1/decisions/conduit-push-abc123', { credential: gatewayCredential });
+  assert.deepEqual(afterDuplicate.json, { status: 'answered', answer: 'Red' });
+
   // Empty answers are rejected outright.
   const empty = await api('/v1/decisions/conduit-push-abc123', {
     method: 'POST',

--- a/relay/test/decisions.e2e.test.mjs
+++ b/relay/test/decisions.e2e.test.mjs
@@ -115,10 +115,12 @@ test('clarify decision: push → device answer → gateway poll', async () => {
   assert.equal(event.status, 202);
   assert.deepEqual(event.json, { accepted: true, delivered: false });
 
-  // Gateway polls: pending.
+  // Gateway polls: pending. This installation registered with enabled:false,
+  // so no card was delivered and the decision reports deliverable:false —
+  // the plugin's poll loop stops instead of waiting out the full budget.
   const poll = await api('/v1/decisions/conduit-push-abc123', { credential: gatewayCredential });
   assert.equal(poll.status, 200);
-  assert.equal(poll.json.status, 'pending');
+  assert.deepEqual(poll.json, { status: 'pending', deliverable: false });
 
   // Another installation's gateway must not see it.
   const stranger = await api('/v1/installations', {

--- a/relay/test/decisions.e2e.test.mjs
+++ b/relay/test/decisions.e2e.test.mjs
@@ -1,0 +1,190 @@
+import { strict as assert } from 'node:assert';
+import { generateKeyPairSync } from 'node:crypto';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawn } from 'node:child_process';
+import { after, before, test } from 'node:test';
+
+// Full clarify answer loop against a real relay process: register a device,
+// pair a gateway, push a clarify decision event (preferences disabled so no
+// APNs call is attempted — the pending decision is still stored), answer from
+// the device, and poll from the gateway. Nothing is mocked.
+
+const dir = mkdtempSync(join(tmpdir(), 'conduit-relay-e2e-'));
+const port = 19000 + Math.floor(Math.random() * 1000);
+const baseUrl = `http://127.0.0.1:${port}`;
+const dataPath = join(dir, 'relay-data.json');
+// The ApnsClient constructor parses the key eagerly, so the relay needs a
+// valid ES256 key to boot — an ephemeral one is fine; this test never sends.
+const keyPath = join(dir, 'ephemeral-key.pem');
+const { privateKey } = generateKeyPairSync('ec', { namedCurve: 'P-256' });
+writeFileSync(keyPath, privateKey.export({ type: 'sec1', format: 'pem' }));
+
+let child;
+
+async function api(path, { method = 'GET', body, credential } = {}) {
+  const response = await fetch(`${baseUrl}${path}`, {
+    method,
+    headers: {
+      ...(body !== undefined ? { 'content-type': 'application/json' } : {}),
+      ...(credential ? { authorization: `Bearer ${credential}` } : {}),
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  return { status: response.status, json: await response.json().catch(() => null) };
+}
+
+before(async () => {
+  child = spawn(process.execPath, ['src/server.mjs'], {
+    cwd: new URL('.', import.meta.url).pathname.replace(/\/test\/$/, '/'),
+    env: {
+      ...process.env,
+      HOST: '127.0.0.1',
+      PORT: String(port),
+      PUBLIC_URL: `https://relay-${port}.example`,
+      DATA_PATH: dataPath,
+      APNS_KEY_PATH: keyPath,
+      APNS_KEY_ID: 'AAAAAAAAAA',
+      APNS_TEAM_ID: 'BBBBBBBBBB',
+      APNS_TOPIC: 'com.milim.relay',
+    },
+    stdio: 'ignore',
+  });
+  const deadline = Date.now() + 10_000;
+  for (;;) {
+    try {
+      const probe = await fetch(`${baseUrl}/healthz`);
+      if (probe.ok) break;
+    } catch {}
+    if (Date.now() > deadline) throw new Error('relay did not start');
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+});
+
+after(() => {
+  child?.kill('SIGTERM');
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test('clarify decision: push → device answer → gateway poll', async () => {
+  // Device registers with notifications disabled so event delivery skips APNs.
+  const registered = await api('/v1/installations', {
+    method: 'POST',
+    body: {
+      bundle_id: 'com.milim.relay',
+      device_token: 'a'.repeat(64),
+      environment: 'production',
+      preferences: { enabled: false, decision_cards: true },
+    },
+  });
+  assert.equal(registered.status, 201);
+  const deviceCredential = registered.json.credential;
+  const installationId = registered.json.installation.id;
+
+  // Pair a gateway (device creates the code, gateway claims it).
+  const pairing = await api(`/v1/installations/${installationId}/pairings`, {
+    method: 'POST',
+    credential: deviceCredential,
+  });
+  assert.equal(pairing.status, 201);
+  const claimed = await api('/v1/pairings/claim', {
+    method: 'POST',
+    body: { pairing_code: pairing.json.pairing_code, gateway_name: 'test gateway' },
+  });
+  assert.equal(claimed.status, 200);
+  const gatewayCredential = claimed.json.credential;
+
+  // Gateway pushes a clarify decision.
+  const event = await api('/v1/events', {
+    method: 'POST',
+    credential: gatewayCredential,
+    body: {
+      type: 'input.needed',
+      event_id: 'input:abcdef123456',
+      session_id: 'sess-1',
+      profile: 'default',
+      decision: {
+        kind: 'clarify',
+        request_id: 'conduit-push-abc123',
+        question: 'Which color?',
+        choices: ['Red', 'Blue'],
+      },
+    },
+  });
+  assert.equal(event.status, 202);
+  assert.deepEqual(event.json, { accepted: true, delivered: false });
+
+  // Gateway polls: pending.
+  const poll = await api('/v1/decisions/conduit-push-abc123', { credential: gatewayCredential });
+  assert.equal(poll.status, 200);
+  assert.equal(poll.json.status, 'pending');
+
+  // Another installation's gateway must not see it.
+  const stranger = await api('/v1/installations', {
+    method: 'POST',
+    body: { bundle_id: 'com.milim.relay', device_token: 'b'.repeat(64), environment: 'production' },
+  });
+  const strangerClaim = await api(`/v1/installations/${stranger.json.installation.id}/pairings`, {
+    method: 'POST',
+    credential: stranger.json.credential,
+  });
+  const strangerGateway = await api('/v1/pairings/claim', {
+    method: 'POST',
+    body: { pairing_code: strangerClaim.json.pairing_code, gateway_name: 'stranger' },
+  });
+  const strangerPoll = await api('/v1/decisions/conduit-push-abc123', {
+    credential: strangerGateway.json.credential,
+  });
+  assert.equal(strangerPoll.status, 200);
+  assert.equal(strangerPoll.json.status, 'unknown');
+
+  // The stranger device cannot answer either.
+  const strangerAnswer = await api('/v1/decisions/conduit-push-abc123', {
+    method: 'POST',
+    credential: stranger.json.credential,
+    body: { answer: 'Blue' },
+  });
+  assert.equal(strangerAnswer.status, 404);
+
+  // The paired device answers; the gateway observes the answer.
+  const answer = await api('/v1/decisions/conduit-push-abc123', {
+    method: 'POST',
+    credential: deviceCredential,
+    body: { answer: 'Red' },
+  });
+  assert.equal(answer.status, 200);
+  assert.equal(answer.json.status, 'answered');
+
+  const answered = await api('/v1/decisions/conduit-push-abc123', { credential: gatewayCredential });
+  assert.equal(answered.status, 200);
+  assert.deepEqual(answered.json, { status: 'answered', answer: 'Red' });
+
+  // Second answer attempts are rejected.
+  const reanswer = await api('/v1/decisions/conduit-push-abc123', {
+    method: 'POST',
+    credential: deviceCredential,
+    body: { answer: 'Blue' },
+  });
+  assert.equal(reanswer.status, 409);
+
+  // Empty answers are rejected outright.
+  const empty = await api('/v1/decisions/conduit-push-abc123', {
+    method: 'POST',
+    credential: deviceCredential,
+    body: { answer: '   ' },
+  });
+  assert.equal(empty.status, 400);
+
+  // Unknown ids are 404 for devices.
+  const unknown = await api('/v1/decisions/conduit-push-nope', {
+    method: 'POST',
+    credential: deviceCredential,
+    body: { answer: 'x' },
+  });
+  assert.equal(unknown.status, 404);
+
+  // Credentials are enforced on both endpoints.
+  const unauth = await api('/v1/decisions/conduit-push-abc123');
+  assert.equal(unauth.status, 401);
+});

--- a/relay/test/decisions.test.mjs
+++ b/relay/test/decisions.test.mjs
@@ -13,6 +13,15 @@ function store() {
   return new RelayStore(join(dir, `store-${Math.random().toString(36).slice(2)}.json`));
 }
 
+test('a same-id write from another installation never clobbers a parked decision', () => {
+  const relay = store();
+  relay.savePendingDecision({ id: 'conduit-push-x', installationId: 'inst-1', gatewayId: 'gw-1', question: 'q' });
+  relay.savePendingDecision({ id: 'conduit-push-x', installationId: 'inst-2', gatewayId: 'gw-2', question: 'evil' });
+  assert.equal(relay.pendingDecisionStatus('inst-1', 'gw-1', 'conduit-push-x').status, 'pending');
+  // The original installation can still answer its own decision.
+  assert.equal(relay.respondPendingDecision('inst-1', 'conduit-push-x', 'Red'), 'answered');
+});
+
 test('pending decision lifecycle: save → pending → answered → already', () => {
   const relay = store();
   relay.savePendingDecision({

--- a/relay/test/decisions.test.mjs
+++ b/relay/test/decisions.test.mjs
@@ -1,0 +1,68 @@
+import { strict as assert } from 'node:assert';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { after, test } from 'node:test';
+
+import { RelayStore } from '../src/store.mjs';
+
+const dir = mkdtempSync(join(tmpdir(), 'conduit-relay-decisions-'));
+after(() => rmSync(dir, { recursive: true, force: true }));
+
+function store() {
+  return new RelayStore(join(dir, `store-${Math.random().toString(36).slice(2)}.json`));
+}
+
+test('pending decision lifecycle: save → pending → answered → already', () => {
+  const relay = store();
+  relay.savePendingDecision({
+    id: 'conduit-push-abc123',
+    installationId: 'inst-1',
+    gatewayId: 'gw-1',
+    question: 'Which color?',
+    choices: ['Red', 'Blue'],
+  });
+
+  assert.deepEqual(
+    relay.pendingDecisionStatus('inst-1', 'gw-1', 'conduit-push-abc123'),
+    { status: 'pending' },
+  );
+  // Cross-installation and cross-gateway reads never see it.
+  assert.deepEqual(relay.pendingDecisionStatus('inst-2', 'gw-1', 'conduit-push-abc123'), { status: 'unknown' });
+  assert.deepEqual(relay.pendingDecisionStatus('inst-1', 'gw-2', 'conduit-push-abc123'), { status: 'unknown' });
+  assert.deepEqual(relay.pendingDecisionStatus('inst-1', 'gw-1', 'nope'), { status: 'unknown' });
+
+  assert.equal(relay.respondPendingDecision('inst-1', 'conduit-push-abc123', 'Red'), 'answered');
+  assert.deepEqual(
+    relay.pendingDecisionStatus('inst-1', 'gw-1', 'conduit-push-abc123'),
+    { status: 'answered', answer: 'Red' },
+  );
+  // A device from another installation cannot answer or re-answer.
+  assert.equal(relay.respondPendingDecision('inst-2', 'conduit-push-abc123', 'Blue'), 'unknown');
+  assert.equal(relay.respondPendingDecision('inst-1', 'conduit-push-abc123', 'Blue'), 'already_answered');
+  assert.equal(relay.pendingDecisionStatus('inst-1', 'gw-1', 'conduit-push-abc123').answer, 'Red');
+});
+
+test('pending decisions survive a reload and expire past the TTL', () => {
+  const path = join(dir, `store-${Math.random().toString(36).slice(2)}.json`);
+  const first = new RelayStore(path);
+  first.savePendingDecision({ id: 'conduit-push-old', installationId: 'inst-1', gatewayId: 'gw-1', question: 'q' });
+
+  const reloaded = new RelayStore(path);
+  assert.equal(reloaded.pendingDecisionStatus('inst-1', 'gw-1', 'conduit-push-old').status, 'pending');
+
+  // Age the record past the 2h TTL directly, then let any access prune it.
+  reloaded.data.pendingDecisions['conduit-push-old'].createdAt = Date.now() - 3 * 60 * 60_000;
+  assert.deepEqual(reloaded.pendingDecisionStatus('inst-1', 'gw-1', 'conduit-push-old'), { status: 'unknown' });
+});
+
+test('pending decision store is bounded', () => {
+  const relay = store();
+  for (let i = 0; i < 300; i += 1) {
+    relay.savePendingDecision({ id: `conduit-push-${i}`, installationId: 'inst-1', gatewayId: 'gw-1', question: 'q' });
+  }
+  assert.ok(Object.keys(relay.data.pendingDecisions).length <= 256);
+  // Oldest entries were evicted; the newest survives.
+  assert.equal(relay.pendingDecisionStatus('inst-1', 'gw-1', 'conduit-push-0').status, 'unknown');
+  assert.equal(relay.pendingDecisionStatus('inst-1', 'gw-1', 'conduit-push-299').status, 'pending');
+});

--- a/relay/test/decisions.test.mjs
+++ b/relay/test/decisions.test.mjs
@@ -25,7 +25,27 @@ test('pending decision lifecycle: save → pending → answered → already', ()
 
   assert.deepEqual(
     relay.pendingDecisionStatus('inst-1', 'gw-1', 'conduit-push-abc123'),
-    { status: 'pending' },
+    { status: 'pending', deliverable: true },
+  );
+  // Deliverability is recorded at intake: a decision whose card device
+  // preferences suppressed reports deliverable:false so the plugin's poll
+  // can stop early.
+  relay.savePendingDecision({
+    id: 'conduit-push-hidden',
+    installationId: 'inst-1',
+    gatewayId: 'gw-1',
+    question: 'q',
+    deliverable: false,
+  });
+  assert.deepEqual(
+    relay.pendingDecisionStatus('inst-1', 'gw-1', 'conduit-push-hidden'),
+    { status: 'pending', deliverable: false },
+  );
+  // Legacy records without the flag default to deliverable.
+  relay.data.pendingDecisions['conduit-push-hidden'].deliverable = undefined;
+  assert.deepEqual(
+    relay.pendingDecisionStatus('inst-1', 'gw-1', 'conduit-push-hidden'),
+    { status: 'pending', deliverable: true },
   );
   // Cross-installation and cross-gateway reads never see it.
   assert.deepEqual(relay.pendingDecisionStatus('inst-2', 'gw-1', 'conduit-push-abc123'), { status: 'unknown' });

--- a/relay/test/server.test.mjs
+++ b/relay/test/server.test.mjs
@@ -5,6 +5,13 @@ import { notificationFor, validateEvent, validateDecision } from '../src/server.
 
 const preferences = { show_previews: true, completion_sound: false };
 
+const clarifyDecision = {
+  kind: 'clarify',
+  request_id: 'conduit-push-abc123',
+  question: 'Which color?',
+  choices: ['Red', 'Blue'],
+};
+
 const approvalDecision = {
   kind: 'approval',
   session_key: 'sess-1',
@@ -91,12 +98,28 @@ test('notificationFor degrades to a routing stub when the payload would exceed t
 
 test('validateDecision only accepts approval decisions on approval events', () => {
   assert.equal(validateDecision(approvalDecision, 'approval.needed').kind, 'approval');
-  // Not shipped yet: clarify cannot be answered from the payload.
-  assert.equal(validateDecision({ kind: 'clarify', request_id: 'r', question: 'q' }, 'input.needed'), undefined);
+  // Clarify is its own contract, bound to input.needed with a plugin-minted
+  // request id; it may not ride an approval event.
+  assert.equal(validateDecision(clarifyDecision, 'approval.needed'), undefined);
   // Kind and event type must agree.
   assert.equal(validateDecision(approvalDecision, 'input.needed'), undefined);
   assert.equal(validateDecision(approvalDecision, 'response.ready'), undefined);
   assert.equal(validateDecision({ kind: 'sudo', session_key: 's', description: 'd', choices: ['once'] }, 'approval.needed'), undefined);
+});
+
+test('validateDecision accepts the clarify contract on input events', () => {
+  assert.deepEqual(
+    validateDecision(clarifyDecision, 'input.needed'),
+    { kind: 'clarify', request_id: 'conduit-push-abc123', question: 'Which color?', choices: ['Red', 'Blue'] },
+  );
+  // Answerability (request id) and display text (question) are both required.
+  assert.equal(validateDecision({ kind: 'clarify', question: 'Which color?' }, 'input.needed'), undefined);
+  assert.equal(validateDecision({ kind: 'clarify', request_id: 'conduit-push-abc123' }, 'input.needed'), undefined);
+  // Open-ended clarifies (no choices) are valid.
+  assert.deepEqual(
+    validateDecision({ kind: 'clarify', request_id: 'conduit-push-abc123', question: 'What next?' }, 'input.needed'),
+    { kind: 'clarify', request_id: 'conduit-push-abc123', question: 'What next?' },
+  );
 });
 
 test('validateDecision whitelists choices to the approval vocabulary', () => {

--- a/tests/test_clarify_loop.py
+++ b/tests/test_clarify_loop.py
@@ -215,3 +215,59 @@ def test_dict_shaped_choices_flatten_to_labels():
     finally:
         release.set()
     assert fake.enqueued[0]["decision"]["choices"] == ["Ship it", "Hold", "Ask user"]
+
+
+def test_child_sessions_keep_the_original_path():
+    fake = _FakeState([])
+    _install(fake)
+    kwargs = _kwargs(lambda a: "original", {"question": "Q?"}, session_id="child-1")
+    result = loop.middleware(is_child_session=lambda session_id: session_id == "child-1", **kwargs)
+    assert result == "original"
+    assert fake.enqueued == []
+    # The parent session still engages the loop.
+    parent_kwargs = _kwargs(lambda a: "original", {"question": "Q?"}, session_id="parent-1")
+    loop.middleware(is_child_session=lambda session_id: session_id == "child-1", **parent_kwargs)
+    assert len(fake.enqueued) == 1
+
+
+def test_polling_stops_when_relay_expires_the_decision():
+    # pending once, then unknown: the relay's 2h TTL expired the decision.
+    # The loop must stop polling (no third request) and wait for the
+    # original path instead of hammering a request that can never succeed.
+    fake = _FakeState([{"status": "pending"}, {"status": "unknown"}, {"status": "pending"}])
+    _install(fake)
+    original, release = _blocking_original("late original result")
+    try:
+        result = loop.middleware(**_kwargs(original, {"question": "Q?"}))
+    finally:
+        release.set()
+    assert result == "late original result"
+    assert len(fake.poll_ids) == 2, "polling must stop after unknown-following-pending"
+
+
+def test_unknown_before_first_pending_is_tolerated():
+    # The push event and the first poll race (enqueue is async), so an early
+    # unknown must NOT be treated as expiry; polling continues to the answer.
+    fake = _FakeState([
+        {"status": "unknown"},
+        {"status": "pending"},
+        {"status": "answered", "answer": "Blue"},
+    ])
+    _install(fake)
+    original, release = _blocking_original()
+    try:
+        result = loop.middleware(**_kwargs(original, {"question": "Q?"}))
+    finally:
+        release.set()
+    assert json.loads(result)["user_response"] == "Blue"
+    assert len(fake.poll_ids) == 3
+
+
+def test_poll_budget_coerces_string_timeout():
+    sys.modules["tools.clarify_gateway"] = types.SimpleNamespace(get_clarify_timeout=lambda: "3600")
+    try:
+        assert loop._clarify_poll_budget() == 3630.0
+        sys.modules["tools.clarify_gateway"] = types.SimpleNamespace(get_clarify_timeout=lambda: 0)
+        assert loop._clarify_poll_budget() == loop.MAX_POLL_SECONDS
+    finally:
+        sys.modules.pop("tools.clarify_gateway", None)

--- a/tests/test_clarify_loop.py
+++ b/tests/test_clarify_loop.py
@@ -1,0 +1,217 @@
+import importlib.util
+import json
+import pathlib
+import sys
+import tempfile
+import threading
+import types
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+# client.py imports the Hermes runtime for the state path; tests only exercise
+# functions that never touch it, so provide a stub before loading the plugin.
+if "hermes_constants" not in sys.modules:
+    _hermes_constants = types.ModuleType("hermes_constants")
+    _hermes_constants.get_hermes_home = lambda: pathlib.Path(tempfile.gettempdir())
+    sys.modules["hermes_constants"] = _hermes_constants
+
+# _format_result imports the real strip_recommended from the Hermes runtime;
+# mirror its exact semantics so formatting assertions match production.
+if "tools" not in sys.modules:
+    _tools = types.ModuleType("tools")
+    _tools.__path__ = []
+    sys.modules["tools"] = _tools
+if "tools.clarify_tool" not in sys.modules:
+    _clarify_tool = types.ModuleType("tools.clarify_tool")
+
+    def _strip_recommended(text):
+        stripped = str(text).strip()
+        suffix = "(Recommended)"
+        if stripped.casefold().endswith(suffix.casefold()):
+            return stripped[: -len(suffix)].strip()
+        return stripped
+
+    _clarify_tool.strip_recommended = _strip_recommended
+    sys.modules["tools.clarify_tool"] = _clarify_tool
+
+# The repo directory name is hyphenated, so import the plugin modules under a
+# synthetic package (the same trick Hermes's plugin loader performs).
+if "conduit_push" not in sys.modules:
+    _pkg = types.ModuleType("conduit_push")
+    _pkg.__path__ = [str(ROOT)]
+    sys.modules["conduit_push"] = _pkg
+if "conduit_push.clarify_loop" not in sys.modules:
+    _spec = importlib.util.spec_from_file_location("conduit_push.clarify_loop", ROOT / "clarify_loop.py")
+    _module = importlib.util.module_from_spec(_spec)
+    sys.modules["conduit_push.clarify_loop"] = _module
+    _spec.loader.exec_module(_module)
+
+import conduit_push.clarify_loop as loop  # noqa: E402
+
+
+class _FakeState:
+    """Stand-in for client.load_state / poll_decision / enqueue."""
+
+    def __init__(self, poll_results):
+        self.paired = True
+        self.poll_results = list(poll_results)
+        self.enqueued = []
+        self.poll_ids = []
+
+    def load_state(self):
+        return {"credential": "x"} if self.paired else None
+
+    def poll_decision(self, request_id):
+        self.poll_ids.append(request_id)
+        if self.poll_results:
+            result = self.poll_results.pop(0)
+            if isinstance(result, Exception):
+                raise result
+            return result
+        return {"status": "pending"}
+
+    def enqueue(self, event):
+        self.enqueued.append(event)
+
+
+def _install(fake):
+    loop.client.load_state = fake.load_state
+    loop.client.poll_decision = fake.poll_decision
+    loop.client.enqueue = fake.enqueue
+    loop.POLL_INTERVAL_SECONDS = 0.01
+
+
+def _kwargs(next_call, args, **extra):
+    return {"tool_name": "clarify", "args": args, "next_call": next_call, "session_id": "sess-1", **extra}
+
+
+def test_non_clarify_tools_pass_through_untouched():
+    fake = _FakeState([])
+    _install(fake)
+    calls = []
+    result = loop.middleware(tool_name="read_file", args={"path": "x"}, next_call=lambda a: calls.append(a) or "original")
+    assert result == "original"
+    assert fake.enqueued == []
+    assert calls == [{"path": "x"}]
+
+
+def test_unpaired_profile_keeps_original_path_only():
+    fake = _FakeState([])
+    fake.paired = False
+    _install(fake)
+    result = loop.middleware(**_kwargs(lambda a: "original", {"question": "Q?"}))
+    assert result == "original"
+    assert fake.enqueued == []
+
+
+def test_relay_answer_wins_and_formats_like_the_builtin_tool():
+    fake = _FakeState([{"status": "answered", "answer": "Red"}])
+    _install(fake)
+    release = threading.Event()
+
+    def blocking_original(args):
+        release.wait(5)
+        return "never used"
+
+    result = loop.middleware(**_kwargs(blocking_original, {
+        "question": "Which color?",
+        "choices": ["Red", "Blue"],
+    }))
+    release.set()
+    parsed = json.loads(result)
+    assert parsed == {
+        "question": "Which color?",
+        "choices_offered": ["Red", "Blue"],
+        "user_response": "Red",
+    }
+    # The push carried the plugin-minted, answerable decision.
+    event = fake.enqueued[0]
+    assert event["type"] == "input.needed"
+    assert event["body"] == "Which color?"
+    decision = event["decision"]
+    assert decision["kind"] == "clarify"
+    assert decision["request_id"].startswith("conduit-push-")
+    assert decision["question"] == "Which color?"
+    assert decision["choices"] == ["Red", "Blue"]
+    assert fake.poll_ids == [decision["request_id"]]
+
+
+def test_original_answer_wins_when_gateway_responds_first():
+    fake = _FakeState([])
+    _install(fake)
+
+    def original(args):
+        return json.dumps({"question": "Q", "choices_offered": ["A"], "user_response": "A"})
+
+    result = loop.middleware(**_kwargs(original, {"question": "Q"}))
+    assert json.loads(result)["user_response"] == "A"
+
+
+def _blocking_original(unused_value="unused"):
+    release = threading.Event()
+    holder = {}
+
+    def original(args):
+        release.wait(5)
+        return unused_value
+
+    return original, release
+
+
+def test_poll_transport_errors_are_tolerated_until_answered():
+    fake = _FakeState([
+        RuntimeError("network down"),
+        {"status": "pending"},
+        {"status": "answered", "answer": "Blue"},
+    ])
+    _install(fake)
+    original, release = _blocking_original()
+    try:
+        result = loop.middleware(**_kwargs(original, {"question": "Q?"}))
+    finally:
+        release.set()
+    assert json.loads(result)["user_response"] == "Blue"
+
+
+def test_recommended_label_is_stripped_from_relay_answer():
+    fake = _FakeState([{"status": "answered", "answer": "Rebase onto main (Recommended)"}])
+    _install(fake)
+    original, release = _blocking_original()
+    try:
+        result = loop.middleware(**_kwargs(original, {
+            "question": "How?",
+            "choices": ["Rebase onto main", "Merge"],
+        }))
+    finally:
+        release.set()
+    assert json.loads(result)["user_response"] == "Rebase onto main"
+
+
+def test_multi_select_answer_parses_json_and_csv():
+    for raw in ('["Red", "Blue"]', "Red, Blue"):
+        fake = _FakeState([{"status": "answered", "answer": raw}])
+        _install(fake)
+        original, release = _blocking_original()
+        try:
+            result = loop.middleware(**_kwargs(original, {
+                "question": "Pick",
+                "choices": ["Red", "Blue"],
+                "multi_select": True,
+            }))
+        finally:
+            release.set()
+        assert json.loads(result)["user_response"] == ["Red", "Blue"]
+
+
+def test_dict_shaped_choices_flatten_to_labels():
+    fake = _FakeState([{"status": "answered", "answer": "Ship it"}])
+    _install(fake)
+    original, release = _blocking_original()
+    try:
+        loop.middleware(**_kwargs(original, {
+            "question": "What now?",
+            "choices": [{"label": "Ship it"}, {"description": "Hold"}, "Ask user"],
+        }))
+    finally:
+        release.set()
+    assert fake.enqueued[0]["decision"]["choices"] == ["Ship it", "Hold", "Ask user"]

--- a/tests/test_clarify_loop.py
+++ b/tests/test_clarify_loop.py
@@ -271,3 +271,35 @@ def test_poll_budget_coerces_string_timeout():
         assert loop._clarify_poll_budget() == loop.MAX_POLL_SECONDS
     finally:
         sys.modules.pop("tools.clarify_gateway", None)
+
+
+def test_polling_stops_when_no_card_was_delivered():
+    # deliverable:false means device preferences suppressed the card; nobody
+    # can answer by id, so the first poll result ends the polling.
+    fake = _FakeState([{"status": "pending", "deliverable": False}, {"status": "pending"}])
+    _install(fake)
+    original, release = _blocking_original("original result")
+    try:
+        result = loop.middleware(**_kwargs(original, {"question": "Q?"}))
+    finally:
+        release.set()
+    assert result == "original result"
+    assert len(fake.poll_ids) == 1
+
+
+def test_consecutive_unknown_polls_stop_after_grace_window():
+    # The push was never parked (dropped at enqueue or delivery): tolerate a
+    # short grace for the delivery race, then stop instead of polling the
+    # entire budget. The later "answered" must never be reached.
+    fake = _FakeState([{"status": "unknown"}] * 5 + [{"status": "answered", "answer": "late"}])
+    _install(fake)
+    original, release = _blocking_original("original result")
+    old_grace = loop.UNKNOWN_POLL_GRACE
+    loop.UNKNOWN_POLL_GRACE = 3
+    try:
+        result = loop.middleware(**_kwargs(original, {"question": "Q?"}))
+    finally:
+        loop.UNKNOWN_POLL_GRACE = old_grace
+        release.set()
+    assert result == "original result"
+    assert len(fake.poll_ids) == 3, "polling must stop at the grace boundary"

--- a/tests/test_clarify_loop.py
+++ b/tests/test_clarify_loop.py
@@ -303,3 +303,66 @@ def test_consecutive_unknown_polls_stop_after_grace_window():
         release.set()
     assert result == "original result"
     assert len(fake.poll_ids) == 3, "polling must stop at the grace boundary"
+
+
+def test_persistent_transport_errors_stop_after_grace_window():
+    # A persistently unreachable relay must not poll the full budget: errors
+    # count against the same grace as unknowns.
+    fake = _FakeState([RuntimeError("relay down")] * 5)
+    _install(fake)
+    original, release = _blocking_original("original result")
+    old_grace = loop.UNKNOWN_POLL_GRACE
+    loop.UNKNOWN_POLL_GRACE = 3
+    try:
+        result = loop.middleware(**_kwargs(original, {"question": "Q?"}))
+    finally:
+        loop.UNKNOWN_POLL_GRACE = old_grace
+        release.set()
+    assert result == "original result"
+    assert len(fake.poll_ids) == 3
+
+
+def test_transport_error_after_pending_does_not_stop_immediately():
+    # A transient blip after the decision was parked keeps polling to the
+    # answer (the grace counter resets on a successful pending/answered view).
+    fake = _FakeState([
+        {"status": "pending"},
+        RuntimeError("blip"),
+        {"status": "answered", "answer": "Blue"},
+    ])
+    _install(fake)
+    original, release = _blocking_original()
+    try:
+        result = loop.middleware(**_kwargs(original, {"question": "Q?"}))
+    finally:
+        release.set()
+    assert json.loads(result)["user_response"] == "Blue"
+
+
+def test_non_question_arg_shapes_still_produce_a_card():
+    # LLMs deviate from the clarify schema; the hook path handled prompt /
+    # message / questions[0] and the loop must too.
+    fake = _FakeState([{"status": "answered", "answer": "Ship it"}])
+    _install(fake)
+    original, release = _blocking_original()
+    try:
+        loop.middleware(**_kwargs(original, {"prompt": "Deploy now?", "choices": ["Ship it"]}))
+    finally:
+        release.set()
+    event = fake.enqueued[0]
+    assert event["body"] == "Deploy now?"
+    assert event["decision"]["question"] == "Deploy now?"
+
+
+def test_poll_delay_backs_off_and_caps():
+    old_base, old_cap = loop.POLL_INTERVAL_SECONDS, loop.MAX_POLL_BACKOFF_SECONDS
+    loop.POLL_INTERVAL_SECONDS = 2.0
+    loop.MAX_POLL_BACKOFF_SECONDS = 10.0
+    try:
+        assert loop._poll_delay(1) == 2.0
+        assert loop._poll_delay(2) == 4.0
+        assert loop._poll_delay(3) == 8.0
+        assert loop._poll_delay(4) == 10.0
+        assert loop._poll_delay(500) == 10.0
+    finally:
+        loop.POLL_INTERVAL_SECONDS, loop.MAX_POLL_BACKOFF_SECONDS = old_base, old_cap

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -105,17 +105,18 @@ def test_sanitize_decision_does_not_coerce_none_into_strings():
     assert decision["choices"] == ["once", "deny"]
 
 
-def test_push_event_only_attaches_approval_decisions_on_approval_events():
-    # Only the approval contract ships; clarify is not answerable from a
-    # payload and the relay rejects it, so it is never emitted or accepted.
-    clarify_decision = {"kind": "clarify", "request_id": "r1", "question": "Which?", "choices": ["a"]}
-    approval_decision = {"kind": "approval", "session_key": "s", "description": "d", "choices": ["once"]}
+def test_push_event_binds_decision_kind_to_event_type():
+    # Approval rides approval.needed; clarify (relay-loop, plugin-minted id)
+    # rides input.needed. Cross-pairings are dropped so the two contracts can
+    # never disagree.
+    clarify_payload = {"kind": "clarify", "request_id": "conduit-push-r1", "question": "Which?", "choices": ["a"]}
+    approval_payload = {"kind": "approval", "session_key": "s", "description": "d", "choices": ["once"]}
 
     event = push_event(
         "approval.needed",
         identifier="approval:12345678",
         session_id="s",
-        decision=clarify_decision,
+        decision=clarify_payload,
     )
     assert "decision" not in event
 
@@ -123,9 +124,47 @@ def test_push_event_only_attaches_approval_decisions_on_approval_events():
         "input.needed",
         identifier="input:12345678",
         session_id="s",
-        decision=approval_decision,
+        decision=approval_payload,
     )
     assert "decision" not in event
+
+
+def test_push_event_attaches_clarify_decision_on_input_events():
+    from events import clarify_decision as build_clarify_decision
+
+    decision = build_clarify_decision(request_id="conduit-push-abc", question="Which?", choices=["Red", "Blue"])
+    event = push_event(
+        "input.needed",
+        identifier="input:12345678",
+        session_id="s",
+        decision=decision,
+    )
+    assert event["decision"] == {
+        "kind": "clarify",
+        "request_id": "conduit-push-abc",
+        "question": "Which?",
+        "choices": ["Red", "Blue"],
+    }
+
+    # Open-ended clarifies (no choices) are valid too.
+    open_ended = build_clarify_decision(request_id="conduit-push-def", question="What next?")
+    event = push_event("input.needed", identifier="input:12345678", session_id="s", decision=open_ended)
+    assert event["decision"]["question"] == "What next?"
+    assert "choices" not in event["decision"]
+
+    # The sanitizer requires the answerable plugin id.
+    assert sanitize_decision({"kind": "clarify", "question": "Which?"}) == {}
+
+
+def test_flatten_choice_labels_unwraps_llm_dict_shapes():
+    from events import flatten_choice_labels
+
+    assert flatten_choice_labels(["Ship it", {"label": "Hold"}, {"description": "Ask"}, {"unknown": "x"}, ""]) == [
+        "Ship it",
+        "Hold",
+        "Ask",
+    ]
+    assert flatten_choice_labels("not-a-list") == []
 
 
 def test_sanitize_decision_requires_choices_and_mirrors_relay_contract():


### PR DESCRIPTION
## Summary

- Clarify decisions raised while the Conduit iOS app is backgrounded become **fully answerable from the push payload** — no upstream gateway changes. The plugin's `tool_execution` middleware mints its own request id, the relay stores the pending decision, the device answers by id, and the middleware polls the relay while the original clarify call keeps serving desktop/CLI clients unchanged.
- Relay gains a bounded pending-decision store plus `POST /v1/decisions/{id}/respond` (device credential) and `GET /v1/decisions/{id}` (gateway credential, polled ~2s while a clarify blocks).

## Why a loop (context)

The gateway mints its clarify request id inside `_block` — no plugin hook sees it — and `clarify.respond` is request-id-only, so unlike approvals (session-keyed) a push card can never answer via the gateway. The chat-platform text-intercept (`resolve_text_response_for_session`) is not wired to the WebSocket path Conduit uses. Details and the full option analysis (visibility-only / plugin loop / upstream patch) are in the companion iOS PR's design doc (`2026-08-14-clarify-cards-relay-loop-design.md`).

## Design notes

- **Wrapping, not replacing**: `agent/tool_executor.py` runs clarify through `_run_agent_tool_execution_middleware`, so the middleware wraps `next_call` (the original tool with the platform callback). Desktop/CLI answering is byte-for-byte unchanged; the gateway's own `clarify.request` still fires. The plugin loop only *adds* an answer path.
- **First answer wins**; the loser resolves into a discarded result on a daemon thread that exits at the clarify timeout. The relay answer is formatted exactly like the built-in tool's JSON (`strip_recommended`, multi-select parse) so the agent cannot tell the paths apart.
- **No double-notify**: the legacy `pre_tool_call` clarify push is skipped when the middleware registered (older gateways without middleware support keep it).
- **Timeout fidelity**: the poll budget follows the gateway's `agent.clarify_timeout` (default 3600s; `<=0` capped at 24h), capped +30s so the original path's timeout always concludes the race.
- **Security**: answers are bounded text; the device credential answers, the gateway credential polls, and the relay enforces installation/gateway match on both (e2e-tested). Decision content stays gated on the `decision_cards` preference.

## Validation

- Middleware unit tests: race outcomes (relay/original wins, transport errors tolerated, unpaired passthrough), answer formatting (label stripping, multi-select JSON/CSV), dict-shaped choice flattening — 8 green.
- Relay: decision lifecycle (pending→answered→already, cross-installation isolation), TTL expiry, bounded store — plus a **nothing-mocked e2e** against a real relay process: register device → pair gateway → push clarify decision → device answer → gateway poll → auth/404/409/400 paths. 14 green.
- Plugin event tests: 12 green. Companion iOS PR: kaishi00/hermes-conduit `clarify-cards-background-arrival`.