### PR TITLE
Report plugin/relay versions and capabilities to the app

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6,7 +6,7 @@ import argparse
 import socket
 
 from .client import DEFAULT_RELAY_URL, claim_pairing, load_state, send_now, state_path, unpair
-from .events import event_id, push_event
+from .events import event_id, plugin_hello, push_event
 
 
 def register_cli(parser: argparse.ArgumentParser) -> None:
@@ -26,6 +26,12 @@ def dispatch(args: argparse.Namespace) -> int:
     if action == "pair":
         state = claim_pairing(args.code, args.relay_url, args.name)
         print(f"Paired {state['gateway_name']} with Conduit.")
+        try:
+            send_now(plugin_hello())
+        except Exception as error:
+            # Pairing succeeded; a failed announcement only means the app's
+            # compatibility view fills in on the first real event instead.
+            print(f"Warning: could not announce plugin version: {error}")
         return 0
     if action == "status":
         state = load_state()

--- a/cli.py
+++ b/cli.py
@@ -27,7 +27,7 @@ def dispatch(args: argparse.Namespace) -> int:
         state = claim_pairing(args.code, args.relay_url, args.name)
         print(f"Paired {state['gateway_name']} with Conduit.")
         try:
-            send_now(plugin_hello())
+            send_now(plugin_hello(), timeout=4.0)
         except Exception as error:
             # Pairing succeeded; a failed announcement only means the app's
             # compatibility view fills in on the first real event instead.

--- a/client.py
+++ b/client.py
@@ -97,7 +97,7 @@ def enqueue(event: dict[str, Any]) -> None:
         logger.warning("Conduit notification queue is full; dropping %s", event.get("type", "event"))
 
 
-def send_now(event: dict[str, Any]) -> dict[str, Any]:
+def send_now(event: dict[str, Any], timeout: float = 15.0) -> dict[str, Any]:
     state = load_state()
     if not state:
         raise RuntimeError("This Hermes profile is not paired with Conduit.")
@@ -106,6 +106,7 @@ def send_now(event: dict[str, Any]) -> dict[str, Any]:
         method="POST",
         credential=state["credential"],
         payload=event,
+        timeout=timeout,
     )
 
 
@@ -132,6 +133,7 @@ def request_json(
     method: str,
     payload: dict[str, Any] | None = None,
     credential: str = "",
+    timeout: float = 15.0,
 ) -> dict[str, Any]:
     data = None if payload is None else json.dumps(payload, separators=(",", ":")).encode("utf-8")
     headers = {
@@ -144,7 +146,7 @@ def request_json(
         headers["Authorization"] = f"Bearer {credential}"
     request = urllib.request.Request(url, data=data, headers=headers, method=method)
     try:
-        with urllib.request.urlopen(request, timeout=15) as response:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
             raw = response.read()
             return json.loads(raw) if raw else {}
     except urllib.error.HTTPError as error:

--- a/events.py
+++ b/events.py
@@ -7,6 +7,15 @@ import json
 import uuid
 from typing import Any
 
+# Keep in sync with plugin.yaml. Reported on every event so the relay can
+# expose per-gateway compatibility state to the app (Settings > Notifications).
+PLUGIN_VERSION = "0.2.0"
+PLUGIN_CAPABILITIES = [
+    "approval-decisions",
+    "clarify-loop",
+    "version-reporting",
+]
+
 
 def event_id(prefix: str, *parts: Any) -> str:
     values = [str(part).strip() for part in parts if str(part or "").strip()]
@@ -26,7 +35,12 @@ def push_event(
     body: str = "",
     decision: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    event: dict[str, Any] = {"event_id": identifier, "type": kind}
+    event: dict[str, Any] = {
+        "event_id": identifier,
+        "type": kind,
+        "plugin_version": PLUGIN_VERSION,
+        "plugin_capabilities": list(PLUGIN_CAPABILITIES),
+    }
     if session_id:
         event["session_id"] = session_id[:180]
     if profile:
@@ -152,6 +166,19 @@ def sanitize_decision(decision: dict[str, Any]) -> dict[str, Any]:
             return {}
         return sanitized
     return {}
+
+
+def plugin_hello() -> dict[str, Any]:
+    """A control event, sent right after pairing, that reports this plugin's
+    version and capabilities without producing a notification. The relay
+    records it so the app can show plugin compatibility immediately instead of
+    waiting for the first real event."""
+    return push_event(
+        "plugin.hello",
+        identifier=event_id("hello", PLUGIN_VERSION),
+        profile="default",
+        body="",
+    )
 
 
 def clarification_text(args: Any) -> str:

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,6 +1,6 @@
 name: conduit_push
 manifest_version: 1
-version: 0.1.0
+version: 0.2.0
 description: "Send Hermes lifecycle notifications to Conduit devices."
 author: Hermes Conduit
 kind: standalone

--- a/relay/package.json
+++ b/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hermes-conduit/push-relay",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/relay/src/server.mjs
+++ b/relay/src/server.mjs
@@ -1,9 +1,20 @@
 import { createServer } from 'node:http';
-import { realpathSync } from 'node:fs';
+import { readFileSync, realpathSync } from 'node:fs';
 import { isIP } from 'node:net';
 import { pathToFileURL } from 'node:url';
 import { ApnsClient } from './apns.mjs';
 import { RelayStore } from './store.mjs';
+
+// Self-reported relay version/capabilities, surfaced via GET /v1/meta so the
+// app can show compatibility state (keep the version in sync with package.json).
+const RELAY_INFO = (() => {
+  try {
+    const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
+    return { version: String(pkg.version || 'unknown'), capabilities: ['decisions', 'decision-cards', 'meta'] };
+  } catch {
+    return { version: 'unknown', capabilities: ['decisions', 'decision-cards', 'meta'] };
+  }
+})();
 
 let config;
 let store;
@@ -135,6 +146,16 @@ async function route(request, response) {
     const body = await readJson(request);
     const event = validateEvent(body);
     if (!store.acceptEvent(installation.id, event.eventId)) return sendJson(response, 200, { accepted: true, duplicate: true });
+    // Every accepted event refreshes the gateway's last-seen plugin version
+    // and capabilities (bounded, cleaned) for the /v1/meta compatibility view.
+    if (event.pluginVersion) {
+      store.recordGatewayPlugin(installation.id, credential.gatewayId, {
+        version: event.pluginVersion,
+        capabilities: event.pluginCapabilities,
+      });
+    }
+    // Control event: version announcement only, never a notification.
+    if (event.type === 'plugin.hello') return sendJson(response, 202, { accepted: true, delivered: false });
     // A clarify decision carries a plugin-minted request id; park it so the
     // device can answer by id and the gateway can poll for the answer while
     // its middleware blocks the tool call. Saved after the dedupe check so a
@@ -198,6 +219,30 @@ async function route(request, response) {
     store.removeGateway(credential.installationId, credential.gatewayId);
     response.writeHead(204).end();
     return;
+  }
+
+  // Compatibility view for Settings > Notifications: the relay's own
+  // version/capabilities plus each paired gateway's last-seen plugin state.
+  // Devices authenticate with their installation credential; older relays
+  // without this endpoint simply 404 and the app renders an unknown state.
+  if (request.method === 'GET' && url.pathname === '/v1/meta') {
+    const credential = bearerCredential(request);
+    if (!credential) return sendJson(response, 401, { error: 'unauthorized' });
+    const installation = store.authenticate(credential.id, credential.secret, 'device');
+    if (!installation) return sendJson(response, 401, { error: 'unauthorized' });
+    enforceRateLimit(`meta:${installation.id}`, 30, 60_000);
+    const gateways = Object.values(installation.gateways ?? {}).map((gateway) => ({
+      id: gateway.id,
+      name: gateway.name,
+      plugin_version: gateway.pluginVersion,
+      plugin_capabilities: gateway.pluginCapabilities ?? [],
+      last_event_at: gateway.lastEventAt,
+    }));
+    return sendJson(response, 200, {
+      version: RELAY_INFO.version,
+      capabilities: RELAY_INFO.capabilities,
+      gateways,
+    });
   }
 
   sendJson(response, 404, { error: 'not_found' });
@@ -293,7 +338,7 @@ function shouldDeliver(preferences, type) {
 }
 
 function validateEvent(body) {
-  const types = new Set(['approval.needed', 'input.needed', 'response.ready', 'turn.failed', 'background_task.finished']);
+  const types = new Set(['approval.needed', 'input.needed', 'response.ready', 'turn.failed', 'background_task.finished', 'plugin.hello']);
   if (!types.has(body.type)) throw httpError(400, 'invalid_event_type');
   const eventId = String(body.event_id ?? '');
   if (!/^[A-Za-z0-9:_-]{8,128}$/.test(eventId)) throw httpError(400, 'invalid_event_id');
@@ -305,6 +350,10 @@ function validateEvent(body) {
     sessionId: cleanIdentifier(body.session_id, 180),
     profile: cleanText(body.profile, 80),
     gateway: cleanIdentifier(body.gateway, 80),
+    pluginVersion: cleanText(body.plugin_version, 40),
+    pluginCapabilities: Array.isArray(body.plugin_capabilities)
+      ? body.plugin_capabilities.map((capability) => cleanIdentifier(capability, 40)).filter((capability) => capability !== undefined).slice(0, 16)
+      : [],
     decision: validateDecision(body.decision, body.type),
   };
 }

--- a/relay/src/server.mjs
+++ b/relay/src/server.mjs
@@ -145,15 +145,17 @@ async function route(request, response) {
     enforceRateLimit(`event:${installation.id}`, 30, 60_000);
     const body = await readJson(request);
     const event = validateEvent(body);
-    if (!store.acceptEvent(installation.id, event.eventId)) return sendJson(response, 200, { accepted: true, duplicate: true });
-    // Every accepted event refreshes the gateway's last-seen plugin version
-    // and capabilities (bounded, cleaned) for the /v1/meta compatibility view.
+    // Plugin version recording runs BEFORE the dedupe return: a second
+    // gateway on the same installation running the same plugin version sends
+    // the same deterministic plugin.hello id, and it must still be recorded.
+    // Re-recording identical state is idempotent, unlike pending decisions.
     if (event.pluginVersion) {
       store.recordGatewayPlugin(installation.id, credential.gatewayId, {
         version: event.pluginVersion,
         capabilities: event.pluginCapabilities,
       });
     }
+    if (!store.acceptEvent(installation.id, event.eventId)) return sendJson(response, 200, { accepted: true, duplicate: true });
     // Control event: version announcement only, never a notification.
     if (event.type === 'plugin.hello') return sendJson(response, 202, { accepted: true, delivered: false });
     // A clarify decision carries a plugin-minted request id; park it so the
@@ -226,6 +228,7 @@ async function route(request, response) {
   // Devices authenticate with their installation credential; older relays
   // without this endpoint simply 404 and the app renders an unknown state.
   if (request.method === 'GET' && url.pathname === '/v1/meta') {
+    enforceRateLimit(`meta-ip:${client}`, 60, 60_000);
     const credential = bearerCredential(request);
     if (!credential) return sendJson(response, 401, { error: 'unauthorized' });
     const installation = store.authenticate(credential.id, credential.secret, 'device');
@@ -350,7 +353,7 @@ function validateEvent(body) {
     sessionId: cleanIdentifier(body.session_id, 180),
     profile: cleanText(body.profile, 80),
     gateway: cleanIdentifier(body.gateway, 80),
-    pluginVersion: cleanText(body.plugin_version, 40),
+    pluginVersion: cleanIdentifier(body.plugin_version, 40),
     pluginCapabilities: Array.isArray(body.plugin_capabilities)
       ? body.plugin_capabilities.map((capability) => cleanIdentifier(capability, 40)).filter((capability) => capability !== undefined).slice(0, 16)
       : [],

--- a/relay/src/store.mjs
+++ b/relay/src/store.mjs
@@ -124,6 +124,23 @@ export class RelayStore {
     return { gatewayId, installationId: installation.id, gatewaySecret };
   }
 
+  // ── Gateway plugin compatibility (Settings > Notifications) ─────────
+  // Every accepted event refreshes the gateway's last-seen plugin version
+  // and capabilities, surfaced via GET /v1/meta.
+
+  recordGatewayPlugin(installationId, gatewayId, { version, capabilities = [] }) {
+    const installation = this.data.installations[installationId];
+    const gateway = installation?.gateways?.[gatewayId];
+    if (!gateway) return;
+    gateway.pluginVersion = String(version || '').slice(0, 40) || undefined;
+    gateway.pluginCapabilities = Array.isArray(capabilities)
+      ? capabilities.map(String).map((capability) => capability.slice(0, 40)).filter(Boolean).slice(0, 16)
+      : [];
+    gateway.lastEventAt = new Date().toISOString();
+    installation.updatedAt = new Date().toISOString();
+    this.save();
+  }
+
   removeGateway(installationId, gatewayId) {
     const installation = this.data.installations[installationId];
     if (!installation?.gateways?.[gatewayId]) return false;

--- a/relay/test/decisions.e2e.test.mjs
+++ b/relay/test/decisions.e2e.test.mjs
@@ -212,4 +212,55 @@ test('clarify decision: push → device answer → gateway poll', async () => {
   // Credentials are enforced on both endpoints.
   const unauth = await api('/v1/decisions/conduit-push-abc123');
   assert.equal(unauth.status, 401);
+
+  // Plugin version announcement: a control event that never notifies but
+  // records the gateway's plugin state for the compatibility view.
+  const hello = await api('/v1/events', {
+    method: 'POST',
+    credential: gatewayCredential,
+    body: {
+      type: 'plugin.hello',
+      // The plugin's event_id hashes the version (hex, no dots); keep the
+      // fixture within the id charset the relay accepts.
+      event_id: 'hello:020abcdef12',
+      plugin_version: '0.2.0',
+      plugin_capabilities: ['approval-decisions', 'clarify-loop', 'version-reporting'],
+    },
+  });
+  assert.equal(hello.status, 202);
+  assert.deepEqual(hello.json, { accepted: true, delivered: false });
+
+  // The device reads relay + plugin compatibility state.
+  const meta = await api('/v1/meta', { credential: deviceCredential });
+  assert.equal(meta.status, 200);
+  assert.equal(meta.json.version, '0.2.0');
+  assert.ok(meta.json.capabilities.includes('decisions'));
+  const gatewayMeta = meta.json.gateways.find((gateway) => gateway.name === 'test gateway');
+  assert.ok(gatewayMeta, 'paired gateway appears in meta');
+  assert.equal(gatewayMeta.plugin_version, '0.2.0');
+  assert.ok(gatewayMeta.plugin_capabilities.includes('clarify-loop'));
+  assert.ok(gatewayMeta.last_event_at);
+
+  // A later real event refreshes the recorded plugin version.
+  await api('/v1/events', {
+    method: 'POST',
+    credential: gatewayCredential,
+    body: {
+      type: 'response.ready',
+      event_id: 'response:abcdef999999',
+      session_id: 'sess-1',
+      plugin_version: '0.2.1',
+      plugin_capabilities: ['approval-decisions', 'clarify-loop'],
+    },
+  });
+  const metaAfter = await api('/v1/meta', { credential: deviceCredential });
+  const refreshed = metaAfter.json.gateways.find((gateway) => gateway.name === 'test gateway');
+  assert.equal(refreshed.plugin_version, '0.2.1');
+
+  // Meta requires the device credential, and never leaks cross-installation.
+  const metaUnauth = await api('/v1/meta');
+  assert.equal(metaUnauth.status, 401);
+  const strangerMeta = await api('/v1/meta', { credential: stranger.json.credential });
+  assert.equal(strangerMeta.status, 200);
+  assert.ok(strangerMeta.json.gateways.every((gateway) => gateway.name !== 'test gateway'), 'cross-installation gateways never leak');
 });

--- a/relay/test/decisions.e2e.test.mjs
+++ b/relay/test/decisions.e2e.test.mjs
@@ -257,6 +257,32 @@ test('clarify decision: push → device answer → gateway poll', async () => {
   const refreshed = metaAfter.json.gateways.find((gateway) => gateway.name === 'test gateway');
   assert.equal(refreshed.plugin_version, '0.2.1');
 
+  // A second gateway on the same installation running the same plugin version
+  // sends the same deterministic hello id; it must still be recorded even
+  // though the event itself dedupes.
+  const secondPairing = await api(`/v1/installations/${installationId}/pairings`, {
+    method: 'POST',
+    credential: deviceCredential,
+  });
+  const secondClaim = await api('/v1/pairings/claim', {
+    method: 'POST',
+    body: { pairing_code: secondPairing.json.pairing_code, gateway_name: 'second gateway' },
+  });
+  await api('/v1/events', {
+    method: 'POST',
+    credential: secondClaim.json.credential,
+    body: {
+      type: 'plugin.hello',
+      event_id: 'hello:020abcdef12',
+      plugin_version: '0.2.0',
+      plugin_capabilities: ['approval-decisions', 'clarify-loop', 'version-reporting'],
+    },
+  });
+  const metaTwo = await api('/v1/meta', { credential: deviceCredential });
+  const second = metaTwo.json.gateways.find((gateway) => gateway.name === 'second gateway');
+  assert.ok(second, 'second gateway listed');
+  assert.equal(second.plugin_version, '0.2.0', 'duplicate hello id must still record the new gateway');
+
   // Meta requires the device credential, and never leaks cross-installation.
   const metaUnauth = await api('/v1/meta');
   assert.equal(metaUnauth.status, 401);

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -167,6 +167,26 @@ def test_flatten_choice_labels_unwraps_llm_dict_shapes():
     assert flatten_choice_labels("not-a-list") == []
 
 
+def test_events_report_plugin_version_and_capabilities():
+    from events import PLUGIN_CAPABILITIES, PLUGIN_VERSION
+
+    event = push_event("response.ready", identifier="response:12345678", session_id="s")
+    assert event["plugin_version"] == PLUGIN_VERSION
+    assert event["plugin_capabilities"] == PLUGIN_CAPABILITIES
+    assert "approval-decisions" in event["plugin_capabilities"]
+    assert "clarify-loop" in event["plugin_capabilities"]
+
+
+def test_plugin_hello_is_a_non_notifying_version_announcement():
+    from events import PLUGIN_VERSION, plugin_hello
+
+    hello = plugin_hello()
+    assert hello["type"] == "plugin.hello"
+    assert hello["plugin_version"] == PLUGIN_VERSION
+    # Stable id per version: replays dedupe, a version bump re-announces.
+    assert plugin_hello() == hello
+
+
 def test_sanitize_decision_requires_choices_and_mirrors_relay_contract():
     # The relay enforces session_key + description + non-empty whitelisted
     # choices; mirror that here so plugin-side tests describe the real contract.

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -187,6 +187,20 @@ def test_plugin_hello_is_a_non_notifying_version_announcement():
     assert plugin_hello() == hello
 
 
+def test_plugin_version_constant_matches_manifest():
+    # PLUGIN_VERSION misreporting compatibility is the failure this feature
+    # exists to prevent; keep the constant and the manifest in lockstep.
+    import pathlib
+    import re
+
+    from events import PLUGIN_VERSION
+
+    manifest = (pathlib.Path(__file__).resolve().parents[1] / "plugin.yaml").read_text()
+    match = re.search(r"^version:\s*(\S+)", manifest, re.MULTILINE)
+    assert match, "plugin.yaml must declare a version"
+    assert match.group(1) == PLUGIN_VERSION
+
+
 def test_sanitize_decision_requires_choices_and_mirrors_relay_contract():
     # The relay enforces session_key + description + non-empty whitelisted
     # choices; mirror that here so plugin-side tests describe the real contract.


### PR DESCRIPTION
## Summary

- The notifier now reports its version and capabilities so the app can show compatibility state in Settings > Notifications: every event carries `plugin_version` + `plugin_capabilities`, and `conduit-push pair` immediately sends a non-notifying `plugin.hello` control event so the state exists right after pairing instead of after the first notification.
- The relay accepts `plugin.hello`, records last-seen plugin state per gateway (refreshed by every accepted event), and exposes `GET /v1/meta` (device credential) with its own version/capabilities plus the paired gateways' plugin state.
- Both bumped to **0.2.0**. Capability flags (`approval-decisions`, `clarify-loop`, `decisions`, `decision-cards`, `meta`) drive checks rather than version-string parsing; older/self-hosted relays without the endpoint 404 and the app renders an unknown state.

## Why this shape

Plugins cannot serve gateway RPCs (verified: `PluginContext` has no RPC registration), so the gateway can't be queried directly — but the app already authenticates to the relay, and the relay sees every event the plugin sends. The relay is the natural aggregation point.

## Validation

- Plugin: event stamping, hello determinism (stable id per version → replays dedupe, a bump re-announces), 21 tests green.
- Relay: 15 tests green incl. e2e — register → pair → `plugin.hello` (no notification produced) → `GET /v1/meta` shows versions/capabilities → a later event refreshes the recorded version → device-credential enforcement and cross-installation isolation.
- Companion iOS PR renders the Compatibility section (kaishi00/hermes-conduit `compatibility-version-reporting`).