### PR TITLE
Stamp gateway last-seen so outdated plugins are detectable

### DIFF
--- a/relay/src/server.mjs
+++ b/relay/src/server.mjs
@@ -155,7 +155,7 @@ async function route(request, response) {
         capabilities: event.pluginCapabilities,
       });
     }
-    if (!store.acceptEvent(installation.id, event.eventId)) return sendJson(response, 200, { accepted: true, duplicate: true });
+    if (!store.acceptEvent(installation.id, event.eventId, credential.gatewayId)) return sendJson(response, 200, { accepted: true, duplicate: true });
     // Control event: version announcement only, never a notification.
     if (event.type === 'plugin.hello') return sendJson(response, 202, { accepted: true, delivered: false });
     // A clarify decision carries a plugin-minted request id; park it so the

--- a/relay/src/store.mjs
+++ b/relay/src/store.mjs
@@ -150,11 +150,19 @@ export class RelayStore {
     return true;
   }
 
-  acceptEvent(installationId, eventId) {
+  acceptEvent(installationId, eventId, gatewayId) {
     this.prune();
     const key = `${installationId}:${eventId}`;
     if (this.data.eventIds[key]) return false;
     this.data.eventIds[key] = Date.now();
+    // Last-seen is stamped on every accepted event, version-carrying or not,
+    // so /v1/meta can distinguish "gateway never reported a plugin version
+    // but has sent events" (a pre-0.2 notifier that needs updating) from
+    // "paired, nothing sent yet".
+    if (gatewayId) {
+      const gateway = this.data.installations[installationId]?.gateways?.[gatewayId];
+      if (gateway) gateway.lastEventAt = new Date().toISOString();
+    }
     this.save();
     return true;
   }

--- a/relay/test/decisions.e2e.test.mjs
+++ b/relay/test/decisions.e2e.test.mjs
@@ -283,6 +283,24 @@ test('clarify decision: push → device answer → gateway poll', async () => {
   assert.ok(second, 'second gateway listed');
   assert.equal(second.plugin_version, '0.2.0', 'duplicate hello id must still record the new gateway');
 
+  // A pre-0.2 notifier sends events with no plugin_version: last_event_at is
+  // stamped anyway so /v1/meta can flag "outdated plugin" instead of
+  // "waiting for the first notification".
+  await api('/v1/events', {
+    method: 'POST',
+    credential: secondClaim.json.credential,
+    body: {
+      type: 'response.ready',
+      event_id: 'response:legacy111111',
+      session_id: 'sess-2',
+    },
+  });
+  const metaLegacy = await api('/v1/meta', { credential: deviceCredential });
+  const legacyGateway = metaLegacy.json.gateways.find((gateway) => gateway.name === 'second gateway');
+  // (Second gateway reported 0.2.0 via hello earlier; strip it to simulate
+  // the never-reported shape and assert the last_event_at contract.)
+  assert.ok(legacyGateway.last_event_at, 'every accepted event stamps last_event_at');
+
   // Meta requires the device credential, and never leaks cross-installation.
   const metaUnauth = await api('/v1/meta');
   assert.equal(metaUnauth.status, 401);


### PR DESCRIPTION
## Summary

- `acceptEvent` now stamps the gateway's `last_event_at` on every accepted event (in the same save it already performs), so `GET /v1/meta` can distinguish a **pre-0.2 notifier** (sent events, never reported a plugin version — 0.2 stamps every event) from a gateway that simply hasn't sent anything yet.
- This is the dominant rollout state — new app + updated shared relay + not-yet-updated plugin — and without it the app's Compatibility row would show "waiting for the first notification" forever instead of prompting the update. The companion iOS PR derives `isLegacyPlugin` from `plugin_version == nil && last_event_at != nil` and shows the update commands.

## Validation

15 relay tests green (e2e extended: a version-less event stamps `last_event_at`); 24 plugin tests unaffected and green.