### PR TITLE
feat: batch-capable clarify decisions end to end (plugin + relay)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,13 +137,24 @@ the FULL batch to Conduit instead of collapsing it to the first question:
   two devices answering the same qid resolve to one lock (the loser gets a
   409), and the decision completes only when every qid is locked.
 - Devices answer per question with
-  `POST /v1/decisions/:id {"question_id": "q…", "answer": "…"}` and receive
-  the remaining open qids back. The legacy whole-decision body
-  (`{"answer": "…"}`) still works for single-question cards, and on a batch
-  it counts as the collapsed first question only.
+  `POST /v1/decisions/:id/respond {"question_id": "q…", "answer": "…"}`
+  and receive the remaining open qids back (`POST /v1/decisions/:id` is
+  kept as a backward-compatible alias running the same handler). The
+  legacy whole-decision body (`{"answer": "…"}`) still works for
+  single-question cards, and on a batch it counts as the collapsed first
+  question only.
+- Duplicate qid answers and released decisions are distinct outcomes:
+  `409 already_answered` settles only that qid as answered elsewhere,
+  while `410 decision_released` (the native Desktop/TUI path resolved the
+  whole clarify) tells Conduit to retire the entire pushed card.
 - The plugin returns the batch to Hermes exactly in the built-in tool's
   result shape (`{"responses": [...]}`, multi-select answers parsed back to
-  lists).
+  lists). Protocol provenance comes from the original invocation: a
+  one-entry `questions[]` call is batch protocol even though it has a
+  single question, while legacy scalar calls keep the scalar result shape.
+- Releasing a decision (native path won) is fired off the answer's critical
+  path on a daemon thread, so a slow or unreachable relay can never delay
+  the user's native answer.
 
 Known limitation: the relay cannot see answers made natively (Hermes
 Desktop/TUI answer through the gateway), and the gateway cannot see relay

--- a/README.md
+++ b/README.md
@@ -146,7 +146,15 @@ the FULL batch to Conduit instead of collapsing it to the first question:
 - Duplicate qid answers and released decisions are distinct outcomes:
   `409 already_answered` settles only that qid as answered elsewhere,
   while `410 decision_released` (the native Desktop/TUI path resolved the
-  whole clarify) tells Conduit to retire the entire pushed card.
+  whole clarify) tells Conduit to retire the entire pushed card. An
+  unknown qid on a live decision is `400 invalid_question_id`, not a
+  missing decision.
+- The structured decision and the notification are independent: when the
+  card cannot be delivered (decision_cards disabled, or an oversized batch
+  stripped by the APNs size guard, or APNs rejecting the send), the
+  ordinary input.needed banner is still delivered and the parked decision
+  is marked `deliverable=false`, so the plugin immediately falls back to
+  Hermes' native clarify path.
 - The plugin returns the batch to Hermes exactly in the built-in tool's
   result shape (`{"responses": [...]}`, multi-select answers parsed back to
   lists). Protocol provenance comes from the original invocation: a

--- a/README.md
+++ b/README.md
@@ -123,6 +123,36 @@ See [`relay/deploy/.env.example`](relay/deploy/.env.example) for all required en
 | POST | `/v1/events` | Deliver a notification event |
 | DELETE | `/v1/gateways/current` | Revoke a gateway credential |
 
+## Batch clarify decisions (plugin 0.3+)
+
+Current Hermes lets one `clarify` call ask several questions
+(`questions: [{qid, question, choices, multi_select}]`). The plugin relays
+the FULL batch to Conduit instead of collapsing it to the first question:
+
+- The pushed decision carries `questions[]` with the gateway qids, choices,
+  and `multi_select` flags. The old collapsed `question`/`choices` summary
+  still rides along, so pre-0.3 Conduit builds keep rendering an answerable
+  first-question card.
+- The relay stores per-question answers with **first-answer-wins per qid**:
+  two devices answering the same qid resolve to one lock (the loser gets a
+  409), and the decision completes only when every qid is locked.
+- Devices answer per question with
+  `POST /v1/decisions/:id {"question_id": "q…", "answer": "…"}` and receive
+  the remaining open qids back. The legacy whole-decision body
+  (`{"answer": "…"}`) still works for single-question cards, and on a batch
+  it counts as the collapsed first question only.
+- The plugin returns the batch to Hermes exactly in the built-in tool's
+  result shape (`{"responses": [...]}`, multi-select answers parsed back to
+  lists).
+
+Known limitation: the relay cannot see answers made natively (Hermes
+Desktop/TUI answer through the gateway), and the gateway cannot see relay
+answers. Whichever surface completes the WHOLE batch first wins the tool
+call; the plugin then releases the parked decision (`DELETE
+/v1/decisions/:id`) so late device answers are rejected rather than
+reported as accepted. A batch answered partly natively and partly by relay
+stays open until the gateway's configured clarify timeout bounds it.
+
 ## Conduit support and privacy
 
 The repository also hosts the public Hermes Conduit support and privacy pages:

--- a/clarify_loop.py
+++ b/clarify_loop.py
@@ -95,6 +95,23 @@ def middleware(is_child_session: Callable[[str], bool] | None = None, **kwargs: 
     labels = list(batch[0]["choices"])
     request_id = f"{REQUEST_ID_PREFIX}{uuid.uuid4().hex[:12]}"
 
+    # The pushed decision's wire shape mirrors the ORIGINAL invocation, not
+    # the normalized list: a legacy scalar call pushes the scalar decision
+    # (no questions[]) so the relay parks it on the scalar path and its
+    # answer returns as {"status": "answered", "answer": ...} — the shape
+    # this module's scalar branch reads. A questions[] call — even a
+    # one-entry one — pushes the batch and completes through per-qid
+    # answers. batch_protocol is the only authoritative discriminator; the
+    # cardinality of `batch` must never decide the wire shape.
+    questions_payload = (
+        [
+            {"qid": entry["qid"], "question": entry["question"], "choices": entry["choices"], "multi_select": entry["multi_select"]}
+            for entry in batch
+        ]
+        if batch_protocol
+        else None
+    )
+
     client.enqueue(push_event(
         "input.needed",
         identifier=event_id("input", kwargs.get("turn_id"), kwargs.get("tool_call_id"), request_id),
@@ -105,10 +122,7 @@ def middleware(is_child_session: Callable[[str], bool] | None = None, **kwargs: 
             request_id=request_id,
             question=question,
             choices=labels or None,
-            questions=[
-                {"qid": entry["qid"], "question": entry["question"], "choices": entry["choices"], "multi_select": entry["multi_select"]}
-                for entry in batch
-            ],
+            questions=questions_payload,
         ),
     ))
 

--- a/clarify_loop.py
+++ b/clarify_loop.py
@@ -182,6 +182,7 @@ def _first_answer_wins(
     saw_pending = False
     consecutive_unproductive = 0
     unanswered_polls = 0
+    previous_remaining: int | None = None
     while time.monotonic() < deadline:
         if "original" in outcome or "original_error" in outcome:
             # The native path resolved the whole call first (desktop/CLI
@@ -233,6 +234,15 @@ def _first_answer_wins(
                 # this notification): nobody can answer by id. Stop polling
                 # and let the original path's timeout conclude the race.
                 break
+            remaining = status.get("remaining")
+            if isinstance(remaining, list):
+                # Batch progress (a shrinking remaining set means another qid
+                # just locked) drops back to the short interval: the next
+                # answer is imminent, and the capped backoff would otherwise
+                # add seconds of dead latency between the remaining answers.
+                if previous_remaining is not None and len(remaining) < previous_remaining:
+                    unanswered_polls = 0
+                previous_remaining = len(remaining)
         elif state == "unknown" and saw_pending:
             # unknown-after-pending: the relay expired the decision (2h TTL,
             # far under an unlimited clarify timeout).

--- a/clarify_loop.py
+++ b/clarify_loop.py
@@ -83,6 +83,11 @@ def middleware(is_child_session: Callable[[str], bool] | None = None, **kwargs: 
     # Reducing the payload to its first question would silently drop
     # questions 2..N from the background path. `question` stays the
     # notification body / collapsed summary for pre-batch Conduit builds.
+    #
+    # Protocol provenance comes from the ORIGINAL invocation — a one-entry
+    # questions[] call is batch protocol and must produce the batch result
+    # shape; cardinality of the normalized list must never decide this.
+    batch_protocol = isinstance(args.get("questions"), list) and len(args["questions"]) > 0
     batch = normalize_clarify_questions(args)
     if not batch:
         return kwargs["next_call"](args)
@@ -112,6 +117,7 @@ def middleware(is_child_session: Callable[[str], bool] | None = None, **kwargs: 
         next_call=kwargs["next_call"],
         args=args,
         batch=batch,
+        batch_protocol=batch_protocol,
     )
 
 
@@ -121,16 +127,18 @@ def _first_answer_wins(
     next_call: Any,
     args: dict[str, Any],
     batch: list[dict[str, Any]],
+    batch_protocol: bool,
 ) -> Any:
     """Race the original clarify call against the relay answer poll.
 
     Single-question decisions resolve on one relay answer, exactly as before.
-    Batch decisions complete only when EVERY qid is locked through the relay;
-    a native (desktop/CLI) completion of the whole original call wins instead,
+    Batch-protocol decisions (a non-empty original ``questions`` array —
+    including exactly one question) complete only when EVERY qid is locked
+    through the relay and format the built-in batch result shape; a native
+    (desktop/CLI) completion of the whole original call wins instead,
     releases the parked decision, and the losing path is discarded.
     """
     outcome: dict[str, Any] = {}
-    batch_mode = len(batch) > 1
     relay_won = False
 
     def _run_original() -> None:
@@ -179,12 +187,12 @@ def _first_answer_wins(
             status = {"status": "__error__"}
         state = str(status.get("status") or "")
         if state == "answered":
-            if batch_mode and "answers" in status:
+            if batch_protocol and "answers" in status:
                 # Complete batch: the relay only reports answered once every
                 # qid is locked, so first-answer-wins held per question.
                 relay_won = True
                 return _format_batch_result(batch, status.get("answers") or {})
-            if not batch_mode:
+            if not batch_protocol:
                 relay_won = True
                 offered = list(batch[0]["choices"])
                 return _format_result(
@@ -193,8 +201,8 @@ def _first_answer_wins(
                     answer=str(status.get("answer") or ""),
                     multi_select=batch[0]["multi_select"],
                 )
-            # A batch decision answered through the legacy collapsed shape
-            # (old relay or pre-batch device): only the first question's
+            # Batch protocol, but the answer arrived in the legacy collapsed
+            # shape (old relay or pre-batch device): only the first question's
             # answer arrived. Format it as a batch result — the unanswered
             # rows surface as empty user_response, the upstream absence
             # semantics — instead of pretending the whole batch was answered.
@@ -238,13 +246,25 @@ def _first_answer_wins(
 
 
 def _release_decision(request_id: str, relay_won: bool) -> None:
-    """Cancel the parked decision when the relay path did not win."""
+    """Cancel the parked decision when the relay path did not win.
+
+    Strictly off the native answer's critical path: the DELETE can wait out
+    the relay's HTTP timeout on a slow or unreachable relay, and the user's
+    native answer must never queue behind it. The cancel is fired on a
+    daemon thread — ordering with tool completion does not matter, because
+    the relay rejects answers to a released decision regardless of whether
+    the release has landed yet.
+    """
     if relay_won:
         return
-    try:
-        client.cancel_decision(request_id)
-    except Exception as error:  # pragma: no cover - defensive
-        logger.warning("Conduit decision release failed for %s: %s", request_id, error)
+
+    def _cancel() -> None:
+        try:
+            client.cancel_decision(request_id)
+        except Exception as error:  # pragma: no cover - defensive
+            logger.warning("Conduit decision release failed for %s: %s", request_id, error)
+
+    threading.Thread(target=_cancel, name="conduit-push-release", daemon=True).start()
 
 
 def _poll_delay(unanswered_polls: int) -> float:

--- a/clarify_loop.py
+++ b/clarify_loop.py
@@ -26,7 +26,12 @@ import uuid
 from typing import Any, Callable
 
 from . import client
-from .events import clarification_text, clarify_decision, event_id, flatten_choice_labels, push_event
+from .events import (
+    clarify_decision,
+    event_id,
+    normalize_clarify_questions,
+    push_event,
+)
 
 logger = logging.getLogger("hermes.plugins.conduit_push")
 
@@ -73,15 +78,16 @@ def middleware(is_child_session: Callable[[str], bool] | None = None, **kwargs: 
         return kwargs["next_call"](kwargs.get("args") or {})
 
     args = dict(kwargs.get("args") or {})
-    # clarification_text handles every question arg shape the hook path
-    # supported (question / prompt / message / questions[0]) -- LLMs do
-    # deviate from the clarify schema, and those shapes must still get a card.
-    question = clarification_text(args)
-    if not question:
+    # The FULL batch is normalized first: current Hermes calls carry
+    # questions[] and legacy scalar calls become a one-question batch.
+    # Reducing the payload to its first question would silently drop
+    # questions 2..N from the background path. `question` stays the
+    # notification body / collapsed summary for pre-batch Conduit builds.
+    batch = normalize_clarify_questions(args)
+    if not batch:
         return kwargs["next_call"](args)
-
-    labels = flatten_choice_labels(args.get("choices"))
-    multi_select = bool(args.get("multi_select"))
+    question = batch[0]["question"]
+    labels = list(batch[0]["choices"])
     request_id = f"{REQUEST_ID_PREFIX}{uuid.uuid4().hex[:12]}"
 
     client.enqueue(push_event(
@@ -90,16 +96,22 @@ def middleware(is_child_session: Callable[[str], bool] | None = None, **kwargs: 
         session_id=session_id,
         profile=profile,
         body=question,
-        decision=clarify_decision(request_id=request_id, question=question, choices=labels or None),
+        decision=clarify_decision(
+            request_id=request_id,
+            question=question,
+            choices=labels or None,
+            questions=[
+                {"qid": entry["qid"], "question": entry["question"], "choices": entry["choices"], "multi_select": entry["multi_select"]}
+                for entry in batch
+            ],
+        ),
     ))
 
     return _first_answer_wins(
         request_id=request_id,
         next_call=kwargs["next_call"],
         args=args,
-        question=question,
-        offered=labels,
-        multi_select=multi_select,
+        batch=batch,
     )
 
 
@@ -108,12 +120,18 @@ def _first_answer_wins(
     request_id: str,
     next_call: Any,
     args: dict[str, Any],
-    question: str,
-    offered: list[str],
-    multi_select: bool,
+    batch: list[dict[str, Any]],
 ) -> Any:
-    """Race the original clarify call against the relay answer poll."""
+    """Race the original clarify call against the relay answer poll.
+
+    Single-question decisions resolve on one relay answer, exactly as before.
+    Batch decisions complete only when EVERY qid is locked through the relay;
+    a native (desktop/CLI) completion of the whole original call wins instead,
+    releases the parked decision, and the losing path is discarded.
+    """
     outcome: dict[str, Any] = {}
+    batch_mode = len(batch) > 1
+    relay_won = False
 
     def _run_original() -> None:
         try:
@@ -144,6 +162,11 @@ def _first_answer_wins(
     unanswered_polls = 0
     while time.monotonic() < deadline:
         if "original" in outcome or "original_error" in outcome:
+            # The native path resolved the whole call first (desktop/CLI
+            # answered through the gateway). Release the parked decision so
+            # a late device answer is rejected (409) instead of being
+            # reported as accepted while its result is discarded.
+            _release_decision(request_id, relay_won)
             if "original_error" in outcome:
                 raise outcome["original_error"]
             return outcome["original"]
@@ -156,11 +179,29 @@ def _first_answer_wins(
             status = {"status": "__error__"}
         state = str(status.get("status") or "")
         if state == "answered":
-            return _format_result(
-                question=question,
-                offered=offered,
-                answer=str(status.get("answer") or ""),
-                multi_select=multi_select,
+            if batch_mode and "answers" in status:
+                # Complete batch: the relay only reports answered once every
+                # qid is locked, so first-answer-wins held per question.
+                relay_won = True
+                return _format_batch_result(batch, status.get("answers") or {})
+            if not batch_mode:
+                relay_won = True
+                offered = list(batch[0]["choices"])
+                return _format_result(
+                    question=batch[0]["question"],
+                    offered=offered,
+                    answer=str(status.get("answer") or ""),
+                    multi_select=batch[0]["multi_select"],
+                )
+            # A batch decision answered through the legacy collapsed shape
+            # (old relay or pre-batch device): only the first question's
+            # answer arrived. Format it as a batch result — the unanswered
+            # rows surface as empty user_response, the upstream absence
+            # semantics — instead of pretending the whole batch was answered.
+            relay_won = True
+            return _format_batch_result(
+                batch,
+                {batch[0]["qid"]: str(status.get("answer") or "")},
             )
         if state == "pending":
             consecutive_unproductive = 0
@@ -184,7 +225,9 @@ def _first_answer_wins(
         time.sleep(_poll_delay(unanswered_polls))
 
     # Poll budget exhausted (unlimited clarify timeout): fall back to whatever
-    # the original path produces, waiting for it if necessary.
+    # the original path produces, waiting for it if necessary. The parked
+    # decision is released first so late device answers are rejected.
+    _release_decision(request_id, relay_won)
     if "original_error" in outcome:
         raise outcome["original_error"]
     while "original" not in outcome and "original_error" not in outcome:
@@ -192,6 +235,16 @@ def _first_answer_wins(
     if "original_error" in outcome:
         raise outcome["original_error"]
     return outcome["original"]
+
+
+def _release_decision(request_id: str, relay_won: bool) -> None:
+    """Cancel the parked decision when the relay path did not win."""
+    if relay_won:
+        return
+    try:
+        client.cancel_decision(request_id)
+    except Exception as error:  # pragma: no cover - defensive
+        logger.warning("Conduit decision release failed for %s: %s", request_id, error)
 
 
 def _poll_delay(unanswered_polls: int) -> float:
@@ -236,6 +289,37 @@ def _format_result(*, question: str, offered: list[str], answer: str, multi_sele
         },
         ensure_ascii=False,
     )
+
+
+def _format_batch_result(batch: list[dict[str, Any]], answers: dict[str, Any]) -> str:
+    """Build the same JSON the built-in clarify_tool returns for a batch.
+
+    Mirrors tools.clarify_tool._batch_result: one row per question in the
+    original order, each carrying the model-supplied id when present, the
+    offered choices, and the cleaned user response (multi-select answers
+    parse back into a list). A qid the relay never locked — only possible
+    through the legacy collapsed-answer path — yields an empty
+    user_response, which upstream defines as an absence rather than a skip.
+    """
+    from tools.clarify_tool import strip_recommended
+
+    responses: list[dict[str, Any]] = []
+    for entry in batch:
+        row: dict[str, Any] = {}
+        if entry.get("id"):
+            row["id"] = entry["id"]
+        row["question"] = entry["question"]
+        row["choices_offered"] = list(entry["choices"])
+        raw = str(answers.get(entry["qid"]) or "")
+        if raw:
+            if entry["multi_select"] and entry["choices"]:
+                row["user_response"] = [strip_recommended(part) for part in _parse_multi_select(raw)]
+            else:
+                row["user_response"] = strip_recommended(raw)
+        else:
+            row["user_response"] = ""
+        responses.append(row)
+    return json.dumps({"responses": responses}, ensure_ascii=False)
 
 
 def _parse_multi_select(raw: str) -> list[str]:

--- a/client.py
+++ b/client.py
@@ -167,6 +167,9 @@ def request_json(
     credential: str = "",
     timeout: float = 15.0,
 ) -> dict[str, Any]:
+    """One relay request. ``timeout`` bounds connect and read, but urllib
+    cannot bound a pathological DNS resolution — accepted technical debt;
+    bounding it would mean a resolver redesign for no realistic gain."""
     data = None if payload is None else json.dumps(payload, separators=(",", ":")).encode("utf-8")
     headers = {
         "Accept": "application/json",

--- a/client.py
+++ b/client.py
@@ -113,9 +113,11 @@ def send_now(event: dict[str, Any], timeout: float = 15.0) -> dict[str, Any]:
 def poll_decision(request_id: str) -> dict[str, Any]:
     """Poll the relay for a push-delivered clarify answer by plugin-minted id.
 
-    Returns {"status": "answered", "answer": str} once the device responded,
-    {"status": "pending"} otherwise. Raises on transport errors so the caller
-    can decide to keep waiting.
+    Returns {"status": "answered", "answer": str} once the device responded
+    to a single-question decision, {"status": "answered", "answers": {...},
+    "remaining": []} for a completed batch, and {"status": "pending",
+    "remaining": [...]} while questions are still open. Raises on transport
+    errors so the caller can decide to keep waiting.
     """
     state = load_state()
     if not state:
@@ -125,6 +127,31 @@ def poll_decision(request_id: str) -> dict[str, Any]:
         method="GET",
         credential=state["credential"],
     )
+
+
+def cancel_decision(request_id: str) -> bool:
+    """Release a parked decision the relay loop can no longer complete.
+
+    Called when the ORIGINAL clarify path won the race (desktop/CLI answered
+    through the gateway) or the poll budget fell back to it: without this, a
+    device answering the stale card would get a 200 "answered" from the relay
+    while the tool result is silently discarded — the card would claim an
+    answer Hermes never received. Best effort by contract: a relay without
+    the endpoint (or a transport blip) must never break the answering path.
+    """
+    try:
+        state = load_state()
+        if not state:
+            return False
+        request_json(
+            f"{state['relay_url'].rstrip('/')}/v1/decisions/{request_id}",
+            method="DELETE",
+            credential=state["credential"],
+        )
+        return True
+    except Exception as error:
+        logger.warning("Conduit decision cancel failed for %s: %s", request_id, error)
+        return False
 
 
 def request_json(

--- a/client.py
+++ b/client.py
@@ -15,8 +15,13 @@ from typing import Any
 
 from hermes_constants import get_hermes_home
 
+from .events import PLUGIN_VERSION
+
 
 DEFAULT_RELAY_URL = "https://push.milim.dev"
+# Derived from PLUGIN_VERSION so a version bump updates the UA automatically
+# (no second hand-synchronized constant).
+USER_AGENT = f"Hermes-Conduit-Notifier/{PLUGIN_VERSION}"
 logger = logging.getLogger("hermes.plugins.conduit_push")
 _events: queue.Queue[dict[str, Any]] = queue.Queue(maxsize=128)
 _worker_started = False
@@ -165,7 +170,7 @@ def request_json(
     data = None if payload is None else json.dumps(payload, separators=(",", ":")).encode("utf-8")
     headers = {
         "Accept": "application/json",
-        "User-Agent": "Hermes-Conduit-Notifier/0.1",
+        "User-Agent": USER_AGENT,
     }
     if data is not None:
         headers["Content-Type"] = "application/json"

--- a/events.py
+++ b/events.py
@@ -9,12 +9,19 @@ from typing import Any
 
 # Keep in sync with plugin.yaml. Reported on every event so the relay can
 # expose per-gateway compatibility state to the app (Settings > Notifications).
-PLUGIN_VERSION = "0.2.0"
+PLUGIN_VERSION = "0.3.0"
 PLUGIN_CAPABILITIES = [
     "approval-decisions",
     "clarify-loop",
+    "batch-clarify-decisions",
     "version-reporting",
 ]
+
+# Bounds for batch clarify decisions, mirroring the single-question limits
+# (8 questions x 8 choices, same text caps) so a pushed batch can never
+# grow past what the relay, APNs, or a card should carry.
+MAX_BATCH_QUESTIONS = 8
+MAX_BATCH_CHOICES = 8
 
 
 def event_id(prefix: str, *parts: Any) -> str:
@@ -82,18 +89,127 @@ def approval_decision(*, session_key: str, description: str) -> dict[str, Any]:
     }
 
 
-def clarify_decision(*, request_id: str, question: str, choices: list[str] | None = None) -> dict[str, Any]:
+def clarify_decision(
+    *,
+    request_id: str,
+    question: str,
+    choices: list[str] | None = None,
+    questions: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
     """Build the structured payload for a clarify notification.
 
     The gateway's own clarify request id is minted inside its blocking prompt
     and unreachable to plugins, so the middleware mints this id and answers
     return through the relay's /v1/decisions endpoints while the original
     clarify callback keeps serving desktop/CLI clients.
+
+    `questions` carries the FULL batch (current Hermes `questions[]`
+    protocol): each entry keeps the gateway qid as identity plus its
+    choices and multi_select flag, so background Conduit devices see and
+    answer every question instead of only the first. The collapsed
+    `question`/`choices` summary stays in the payload for older Conduit
+    builds, which render an answerable first-question card from it.
     """
     decision: dict[str, Any] = {"kind": "clarify", "request_id": request_id, "question": question}
     if choices:
         decision["choices"] = choices
+    if questions:
+        decision["questions"] = questions
     return decision
+
+
+def normalize_clarify_questions(args: Any) -> list[dict[str, Any]]:
+    """Normalize every clarify arg shape into one batch-capable list.
+
+    Accepts the current `questions[]` protocol AND the legacy scalar
+    `question`/`prompt`/`message` shape (which becomes a one-question
+    batch). Nothing is discarded: each entry keeps a stable qid
+    (gateway-style `q<index>` — the same minting the gateway's own bridge
+    uses), the question text, its flattened choice labels, and the
+    multi_select flag. Entries are NEVER reduced to the first question.
+
+    Upstream's own normalizer is used when importable so qid minting and
+    choice flattening match the tool exactly; a local mirror keeps this
+    working against older Hermes installs.
+    """
+    if not isinstance(args, dict):
+        return []
+    raw_questions = args.get("questions")
+    if isinstance(raw_questions, list) and raw_questions:
+        try:
+            from tools.clarify_tool import _normalize_questions
+
+            normalized, error = _normalize_questions(raw_questions)
+            if error is None and normalized:
+                return [
+                    {
+                        "qid": entry["qid"],
+                        "id": entry.get("id"),
+                        "question": entry["question"],
+                        "choices": list(entry["choices_offered"] or []),
+                        "multi_select": bool(entry["multi_select"]),
+                    }
+                    for entry in normalized[:MAX_BATCH_QUESTIONS]
+                ]
+        except Exception:
+            pass
+        return _normalize_questions_locally(raw_questions)
+    text = scalar_question_text(args)
+    if not text:
+        return []
+    labels = flatten_choice_labels(args.get("choices"))
+    return [
+        {
+            "qid": "q0",
+            "id": None,
+            "question": text,
+            "choices": labels,
+            # multi_select without choices degrades exactly like the gateway.
+            "multi_select": bool(args.get("multi_select")) and bool(labels),
+        }
+    ]
+
+
+def scalar_question_text(args: Any) -> str:
+    """The legacy scalar question text, without clarification_text's canned
+    fallback — an unparseable shape must normalize to NO question, never to
+    a synthetic prompt the user would be asked to answer."""
+    if not isinstance(args, dict):
+        return ""
+    for key in ("question", "prompt", "message"):
+        value = args.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
+def _normalize_questions_locally(raw_questions: list[Any]) -> list[dict[str, Any]]:
+    """Local mirror of the upstream batch normalizer (older Hermes installs).
+
+    Minting, flattening, and bounds match tools.clarify_tool._normalize_questions
+    so pushed qids are indistinguishable from gateway-minted ones.
+    """
+    normalized: list[dict[str, Any]] = []
+    for index, item in enumerate(raw_questions[:MAX_BATCH_QUESTIONS]):
+        if isinstance(item, str):
+            item = {"question": item}
+        if not isinstance(item, dict):
+            continue
+        text = str(item.get("question") or "").strip()
+        if not text:
+            continue
+        labels = flatten_choice_labels(item.get("choices"))
+        normalized.append(
+            {
+                "qid": f"q{index}",
+                "id": str(item.get("id") or "").strip() or None,
+                "question": text,
+                "choices": labels,
+                # Upstream honors multi_select only when choices exist.
+                "multi_select": bool(item.get("multi_select")) and bool(labels),
+            }
+        )
+    return normalized
 
 
 def flatten_choice_labels(choices: Any) -> list[str]:
@@ -152,7 +268,7 @@ def sanitize_decision(decision: dict[str, Any]) -> dict[str, Any]:
             return {}
         return sanitized
     if kind == "clarify":
-        sanitized = {"kind": "clarify"}
+        sanitized: dict[str, Any] = {"kind": "clarify"}
         for key in ("request_id", "question"):
             value = _clean(decision.get(key, ""), 500)
             if value:
@@ -161,7 +277,34 @@ def sanitize_decision(decision: dict[str, Any]) -> dict[str, Any]:
         if isinstance(choices, list):
             cleaned = [value for value in (_clean(choice, 80) for choice in choices) if value]
             if cleaned:
-                sanitized["choices"] = cleaned[:8]
+                sanitized["choices"] = cleaned[:MAX_BATCH_CHOICES]
+        # Batch form: the full question set rides alongside the collapsed
+        # summary. Each entry keeps its qid (per-question answer identity),
+        # text, labels, and multi_select flag; one malformed entry is dropped
+        # rather than failing the whole decision.
+        raw_questions = decision.get("questions")
+        if isinstance(raw_questions, list):
+            questions: list[dict[str, Any]] = []
+            for entry in raw_questions[:MAX_BATCH_QUESTIONS]:
+                if not isinstance(entry, dict):
+                    continue
+                qid = _clean(entry.get("qid", ""), 40)
+                text = _clean(entry.get("question", ""), 500)
+                if not qid or not text:
+                    continue
+                question: dict[str, Any] = {"qid": qid, "question": text}
+                labels = entry.get("choices")
+                if isinstance(labels, list):
+                    cleaned_labels = [value for value in (_clean(label, 80) for label in labels) if value]
+                    if cleaned_labels:
+                        question["choices"] = cleaned_labels[:MAX_BATCH_CHOICES]
+                if entry.get("multi_select") is True:
+                    # Strict boolean: a truthy string must not coerce into a
+                    # selected-state flag (mirrors the relay's === true check).
+                    question["multi_select"] = True
+                questions.append(question)
+            if questions:
+                sanitized["questions"] = questions
         if not sanitized.get("request_id") or not sanitized.get("question"):
             return {}
         return sanitized

--- a/events.py
+++ b/events.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 import uuid
 from typing import Any
 
@@ -22,6 +23,11 @@ PLUGIN_CAPABILITIES = [
 # grow past what the relay, APNs, or a card should carry.
 MAX_BATCH_QUESTIONS = 8
 MAX_BATCH_CHOICES = 8
+
+# Same accepted-qid contract as the relay's sanitizeBatchQuestions: this
+# plugin must never emit a batch the relay would silently shrink.
+_QID_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
+_QID_RESERVED = {"__proto__", "constructor", "prototype"}
 
 
 def event_id(prefix: str, *parts: Any) -> str:
@@ -186,18 +192,21 @@ def scalar_question_text(args: Any) -> str:
 def _normalize_questions_locally(raw_questions: list[Any]) -> list[dict[str, Any]]:
     """Local mirror of the upstream batch normalizer (older Hermes installs).
 
-    Minting, flattening, and bounds match tools.clarify_tool._normalize_questions
-    so pushed qids are indistinguishable from gateway-minted ones.
+    Matches tools.clarify_tool._normalize_questions precisely: qids are
+    minted from the RAW position (`q{enumerate index}`), bare-string entries
+    are tolerated, a non-dict entry or an entry without question text
+    rejects the WHOLE batch (upstream returns an error, it never skips), and
+    multi_select is honored only when choices exist.
     """
     normalized: list[dict[str, Any]] = []
     for index, item in enumerate(raw_questions[:MAX_BATCH_QUESTIONS]):
         if isinstance(item, str):
             item = {"question": item}
         if not isinstance(item, dict):
-            continue
+            return []
         text = str(item.get("question") or "").strip()
         if not text:
-            continue
+            return []
         labels = flatten_choice_labels(item.get("choices"))
         normalized.append(
             {
@@ -285,24 +294,36 @@ def sanitize_decision(decision: dict[str, Any]) -> dict[str, Any]:
         raw_questions = decision.get("questions")
         if isinstance(raw_questions, list):
             questions: list[dict[str, Any]] = []
+            seen_qids: set[str] = set()
             for entry in raw_questions[:MAX_BATCH_QUESTIONS]:
                 if not isinstance(entry, dict):
                     continue
                 qid = _clean(entry.get("qid", ""), 40)
+                # Mirror of the relay's sanitizeBatchQuestions: same accepted
+                # charset, same reserved-name rejection, same first-qid-wins
+                # dedup and choice dedup — the relay must never silently
+                # shrink a batch this plugin emits.
+                if not _QID_PATTERN.fullmatch(qid) or qid in _QID_RESERVED or qid in seen_qids:
+                    continue
                 text = _clean(entry.get("question", ""), 500)
-                if not qid or not text:
+                if not text:
                     continue
                 question: dict[str, Any] = {"qid": qid, "question": text}
                 labels = entry.get("choices")
                 if isinstance(labels, list):
-                    cleaned_labels = [value for value in (_clean(label, 80) for label in labels) if value]
+                    cleaned_labels: list[str] = []
+                    for label in labels[:MAX_BATCH_CHOICES]:
+                        cleaned = _clean(label, 80)
+                        if cleaned and cleaned not in cleaned_labels:
+                            cleaned_labels.append(cleaned)
                     if cleaned_labels:
-                        question["choices"] = cleaned_labels[:MAX_BATCH_CHOICES]
+                        question["choices"] = cleaned_labels
                 if entry.get("multi_select") is True:
                     # Strict boolean: a truthy string must not coerce into a
                     # selected-state flag (mirrors the relay's === true check).
                     question["multi_select"] = True
                 questions.append(question)
+                seen_qids.add(qid)
             if questions:
                 sanitized["questions"] = questions
         if not sanitized.get("request_id") or not sanitized.get("question"):

--- a/events.py
+++ b/events.py
@@ -115,6 +115,11 @@ def clarify_decision(
     answer every question instead of only the first. The collapsed
     `question`/`choices` summary stays in the payload for older Conduit
     builds, which render an answerable first-question card from it.
+
+    Legacy scalar invocations pass no `questions`, keeping the decision —
+    and therefore the relay's parked decision and answer shape — scalar
+    end to end. Protocol provenance lives in the original invocation shape,
+    never in the normalized question count.
     """
     decision: dict[str, Any] = {"kind": "clarify", "request_id": request_id, "question": question}
     if choices:

--- a/events.py
+++ b/events.py
@@ -18,9 +18,13 @@ PLUGIN_CAPABILITIES = [
     "version-reporting",
 ]
 
-# Bounds for batch clarify decisions, mirroring the single-question limits
-# (8 questions x 8 choices, same text caps) so a pushed batch can never
-# grow past what the relay, APNs, or a card should carry.
+# PROTOCOL/STORE bounds for batch clarify decisions (8 questions x 8
+# choices, same text caps), mirrored by the relay. This is the maximum a
+# decision may CONTAIN — it is NOT a promise that every valid batch fits an
+# answerable card: APNs caps the whole notification at 4 KB, so a wide or
+# long-text batch can still exceed the relay's payload guard. That case
+# degrades safely (plain banner delivered, decision parked deliverable=false,
+# native clarify path continues) instead of losing the notification.
 MAX_BATCH_QUESTIONS = 8
 MAX_BATCH_CHOICES = 8
 

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,6 +1,6 @@
 name: conduit_push
 manifest_version: 1
-version: 0.2.0
+version: 0.3.0
 description: "Send Hermes lifecycle notifications to Conduit devices."
 author: Hermes Conduit
 kind: standalone

--- a/relay/package.json
+++ b/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hermes-conduit/push-relay",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/relay/src/apns.mjs
+++ b/relay/src/apns.mjs
@@ -2,21 +2,52 @@ import { createPrivateKey, createSign } from 'node:crypto';
 import { connect } from 'node:http2';
 import { readFileSync } from 'node:fs';
 
+// Production origin; the constructor override exists so tests can point the
+// real transport at a failing endpoint (closed port, protocol-breaking peer)
+// without mocking the client away.
+const DEFAULT_APNS_ORIGIN = 'https://api.push.apple.com';
+
 export class ApnsClient {
-  constructor({ keyPath, keyId, teamId, topic }) {
+  constructor({ keyPath, keyId, teamId, topic, origin }) {
     this.keyId = keyId;
     this.teamId = teamId;
     this.topic = topic;
+    this.origin = origin || DEFAULT_APNS_ORIGIN;
     this.privateKey = createPrivateKey(readFileSync(keyPath));
     this.cachedToken = null;
     this.tokenCreatedAt = 0;
   }
 
   async send(deviceToken, notification) {
-    const client = connect('https://api.push.apple.com');
-    try {
-      return await new Promise((resolve, reject) => {
-        const request = client.request({
+    const client = connect(this.origin);
+    return await new Promise((resolve, reject) => {
+      // A failing APNs connection can surface through BOTH the request stream
+      // and the ClientHttp2Session, and a late session error can arrive after
+      // the response already completed. settle-once makes every path settle
+      // the SAME promise exactly once — critically, the session 'error'
+      // handler below is what keeps a connection-level failure (refused,
+      // TLS, GOAWAY, socket reset) from reaching Node as an unhandled
+      // 'error' event, which would terminate the whole relay process.
+      let settled = false;
+      const fail = (error) => {
+        if (settled) return;
+        settled = true;
+        // A failed session cannot shut down gracefully; destroy instead of
+        // close so cleanup itself cannot hang or throw (destroy is safe on
+        // an already-dead session).
+        client.destroy();
+        reject(error);
+      };
+      const succeed = (result) => {
+        if (settled) return;
+        settled = true;
+        client.close();
+        resolve(result);
+      };
+      client.on('error', fail);
+      let request;
+      try {
+        request = client.request({
           ':method': 'POST',
           ':path': `/3/device/${deviceToken}`,
           authorization: `bearer ${this.authorizationToken()}`,
@@ -25,22 +56,39 @@ export class ApnsClient {
           'apns-priority': '10',
           ...(notification.collapseId ? { 'apns-collapse-id': notification.collapseId.slice(0, 64) } : {}),
         });
-        let status = 0;
-        let body = '';
-        request.setEncoding('utf8');
-        request.on('response', (headers) => { status = Number(headers[':status'] ?? 0); });
-        request.on('data', (chunk) => { body += chunk; });
-        request.on('end', () => {
-          let detail = null;
-          try { detail = body ? JSON.parse(body) : null; } catch { detail = null; }
-          resolve({ ok: status === 200, status, reason: detail?.reason ?? null });
-        });
-        request.on('error', reject);
-        request.end(JSON.stringify(notification.payload));
+      } catch (error) {
+        fail(error);
+        return;
+      }
+      let status = 0;
+      let body = '';
+      request.setEncoding('utf8');
+      request.on('response', (headers) => { status = Number(headers[':status'] ?? 0); });
+      request.on('data', (chunk) => { body += chunk; });
+      request.on('end', () => {
+        // A legitimate APNs answer always carries :status; a stream that
+        // ended without one is a transport break (abrupt close, GOAWAY
+        // teardown) — fail it rather than "resolving" a status-0 non-answer
+        // the server would misread as an APNs rejection.
+        if (status === 0) {
+          fail(new Error('apns connection closed before a response arrived'));
+          return;
+        }
+        let detail = null;
+        try { detail = body ? JSON.parse(body) : null; } catch { detail = null; }
+        succeed({ ok: status === 200, status, reason: detail?.reason ?? null });
       });
-    } finally {
-      client.close();
-    }
+      request.on('error', fail);
+      // Final net so the promise settles even if the stream closes without
+      // 'end' or 'error' (settle-once turns later events into no-ops).
+      request.on('close', () => {
+        fail(new Error('apns stream closed before settling'));
+      });
+      request.end(JSON.stringify(notification.payload));
+    });
+    // Each send owns one short-lived session that is closed on success or
+    // destroyed on failure before the promise settles, so its listeners are
+    // released with the session — nothing is attached beyond this call.
   }
 
   authorizationToken() {

--- a/relay/src/apns.mjs
+++ b/relay/src/apns.mjs
@@ -6,6 +6,11 @@ import { readFileSync } from 'node:fs';
 // real transport at a failing endpoint (closed port, protocol-breaking peer)
 // without mocking the client away.
 const DEFAULT_APNS_ORIGIN = 'https://api.push.apple.com';
+// Bound for one APNs send. APNs answers in well under a second in practice;
+// this exists for the one failure shape that emits NO event to settle on —
+// a peer that accepts the connection and then stalls — so the send promise
+// always settles and the intake request can never hang on it.
+const SEND_TIMEOUT_MS = 10_000;
 
 export class ApnsClient {
   constructor({ keyPath, keyId, teamId, topic, origin }) {
@@ -32,7 +37,8 @@ export class ApnsClient {
       const fail = (error) => {
         if (settled) return;
         settled = true;
-        // A failed session cannot shut down gracefully; destroy instead of
+        clearTimeout(stall);
+        // A failed session cannot be closed gracefully; destroy instead of
         // close so cleanup itself cannot hang or throw (destroy is safe on
         // an already-dead session).
         client.destroy();
@@ -41,9 +47,11 @@ export class ApnsClient {
       const succeed = (result) => {
         if (settled) return;
         settled = true;
+        clearTimeout(stall);
         client.close();
         resolve(result);
       };
+      const stall = setTimeout(() => fail(new Error('apns send timed out')), SEND_TIMEOUT_MS);
       client.on('error', fail);
       let request;
       try {
@@ -84,7 +92,11 @@ export class ApnsClient {
       request.on('close', () => {
         fail(new Error('apns stream closed before settling'));
       });
-      request.end(JSON.stringify(notification.payload));
+      try {
+        request.end(JSON.stringify(notification.payload));
+      } catch (error) {
+        fail(error);
+      }
     });
     // Each send owns one short-lived session that is closed on success or
     // destroyed on failure before the promise settles, so its listeners are

--- a/relay/src/server.mjs
+++ b/relay/src/server.mjs
@@ -32,14 +32,20 @@ function main() {
   store = new RelayStore(config.dataPath);
   apns = new ApnsClient(config);
   limits = new Map();
-  // Test seam: APNS_MODE=accept makes every send succeed and APNS_MODE=reject
-  // makes every send fail with a 403 — both without touching the network —
-  // so the e2e suite can exercise delivery outcomes, decision parking, and
-  // APNs-failure cleanup deterministically. Unset = real APNs.
+  // Test seam: APNS_MODE=accept makes every send succeed, reject makes it
+  // return a 403 failure, and throw makes it RAISE (a dropped connection) —
+  // all without touching the network — so the e2e suite can exercise
+  // delivery outcomes, decision parking, and both APNs-failure shapes
+  // (returned rejection and thrown transport error) deterministically.
+  // Unset = real APNs.
   if (process.env.APNS_MODE === 'accept') {
     apnsSend = async () => ({ ok: true, status: 200, reason: null });
   } else if (process.env.APNS_MODE === 'reject') {
     apnsSend = async () => ({ ok: false, status: 403, reason: 'InvalidProviderToken' });
+  } else if (process.env.APNS_MODE === 'throw') {
+    apnsSend = async () => {
+      throw new Error('connection dropped');
+    };
   } else {
     apnsSend = (deviceToken, notification) => apns.send(deviceToken, notification);
   }
@@ -199,9 +205,10 @@ async function route(request, response) {
       const notification = deliverableBase
         ? notificationFor(event, installation.preferences)
         : null;
-      const decisionInPayload = notification?.payload?.conduit?.decision;
-      const decisionDeliverable = decisionInPayload != null
-        && notification?.payload?.body?.conduit?.decision != null;
+      // The rich body copy is the canonical payload the iOS path reads, and
+      // (since the top-level copy became a routing stub) the only place the
+      // structured decision lives.
+      const decisionDeliverable = notification?.payload?.body?.conduit?.decision != null;
       store.savePendingDecision({
         id: parkedDecisionId,
         installationId: installation.id,
@@ -212,7 +219,18 @@ async function route(request, response) {
         deliverable: decisionDeliverable,
       });
       if (!notification) return sendJson(response, 202, { accepted: true, delivered: false });
-      const result = await apnsSend(installation.deviceToken, notification);
+      let result;
+      try {
+        result = await apnsSend(installation.deviceToken, notification);
+      } catch (error) {
+        // A THROWN transport failure (dropped connection, DNS, TLS) is the
+        // same outcome as a returned rejection: no device received the
+        // answerable card, so the parked decision must flip to undeliverable
+        // and the failure must still be reported upstream.
+        store.markPendingDecisionUndeliverable(installation.id, credential.gatewayId, parkedDecisionId);
+        console.error(JSON.stringify({ level: 'error', message: 'apns send threw', error: error instanceof Error ? error.message : String(error) }));
+        return sendJson(response, 502, { error: 'apns_unreachable' });
+      }
       if (result.status === 410 || result.reason === 'BadDeviceToken' || result.reason === 'Unregistered') store.deactivateInstallation(installation.id);
       if (!result.ok) {
         // The answerable card never reached the device: flip the parked
@@ -286,7 +304,9 @@ async function route(request, response) {
     // result nobody reads.
     const credential = gatewayCredential(request);
     if (!credential || !store.authenticateGateway(credential.installationId, credential.gatewayId, credential.secret)) return sendJson(response, 401, { error: 'unauthorized' });
-    enforceRateLimit(`decision-poll:${credential.gatewayId}`, 120, 60_000);
+    // Release has its OWN bucket: heavy clarify polling must never be able
+    // to starve the DELETE that cleans up when the native path wins.
+    enforceRateLimit(`decision-cancel:${credential.gatewayId}`, 30, 60_000);
     const outcome = store.cancelPendingDecision(credential.installationId, credential.gatewayId, decisionMatch[1]);
     if (outcome === 'unknown') return sendJson(response, 404, { error: 'unknown_decision' });
     return sendJson(response, 200, { status: 'cancelled' });
@@ -368,22 +388,26 @@ function notificationFor(event, preferences) {
     profile: event.profile,
     gateway: event.gateway,
   };
-  const conduit = { ...routing, ...(decision ? { decision } : {}) };
+  // body.conduit is the canonical rich payload the iOS notification path
+  // reads (expo-notifications exposes the APNs `body` value as the
+  // notification's data, so a tap can recover session/profile after a cold
+  // start — and this is where the structured decision lives). The top-level
+  // `conduit` copy stays ROUTING-ONLY for raw-APNs consumers: duplicating
+  // the structured decision there once doubled the decision's byte cost and
+  // pushed ordinary multi-question batches over the size guard.
+  const bodyConduit = { ...routing, ...(decision ? { decision } : {}) };
   const aps = {
     alert: { title, body },
     ...(preferences.completion_sound && completion ? { sound: 'default' } : {}),
     'thread-id': event.sessionId ?? 'hermes',
   };
-  // expo-notifications on iOS exposes the top-level APNs `body` value as
-  // `notification.request.content.data`. Keep the Conduit route there so
-  // a notification tap can recover its session/profile after a cold start.
-  // The top-level copy remains for clients that read the raw APNs payload.
-  let payload = { aps, body: { conduit }, conduit };
+  let payload = { aps, body: { conduit: bodyConduit }, conduit: routing };
   // APNs caps the notification payload at 4 KB and rejects anything larger.
-  // A maximal description (500 chars of multi-byte UTF-8, echoed in both
-  // conduit copies) plus the alert copy can approach that, so degrade to the
-  // routing stub instead of losing the whole notification. The headroom under
-  // the 4096 cap absorbs per-request APNs headers and JSON escaping.
+  // With a single structured copy, the guard now measures the real cost of
+  // one decision plus routing and alert copy; a payload that still exceeds
+  // the budget degrades to the routing stub instead of losing the whole
+  // notification. The headroom under the 4096 cap absorbs per-request APNs
+  // headers and JSON escaping.
   if (decision && Buffer.byteLength(JSON.stringify(payload)) > MAX_NOTIFICATION_BYTES) {
     payload = { aps, body: { conduit: routing }, conduit: routing };
   }

--- a/relay/src/server.mjs
+++ b/relay/src/server.mjs
@@ -3,7 +3,7 @@ import { readFileSync, realpathSync } from 'node:fs';
 import { isIP } from 'node:net';
 import { pathToFileURL } from 'node:url';
 import { ApnsClient } from './apns.mjs';
-import { RelayStore } from './store.mjs';
+import { RelayStore, sanitizeBatchQuestions } from './store.mjs';
 
 // Self-reported relay version/capabilities, surfaced via GET /v1/meta so the
 // app can show compatibility state (keep the version in sync with package.json).
@@ -162,10 +162,23 @@ async function route(request, response) {
     // device can answer by id and the gateway can poll for the answer while
     // its middleware blocks the tool call. Saved after the dedupe check so a
     // re-delivered event can never overwrite (and wipe the answer of) the
-    // already-parked decision. `deliverable` records whether device
-    // preferences will actually show an answerable card, so the plugin can
-    // stop polling a decision nobody can answer.
+    // already-parked decision.
+    //
+    // `deliverable` must reflect whether the device will actually receive an
+    // ANSWERABLE card, so the final notification is built first and the flag
+    // is taken from what survived into the APNs payload: device preferences
+    // (input.needed / decision_cards) and the 4 KB size guard can each strip
+    // the structured decision. Marking a decision deliverable when its card
+    // was stripped would make the plugin poll — and a widget-less device
+    // answer — a decision no card can reach.
     if (event.decision?.kind === 'clarify' && event.decision.request_id) {
+      const deliverableBase = shouldDeliver(installation.preferences, event.type);
+      const notification = deliverableBase
+        ? notificationFor(event, installation.preferences)
+        : null;
+      const decisionInPayload = notification?.payload?.conduit?.decision;
+      const deliverable = decisionInPayload != null
+        && notification?.payload?.body?.conduit?.decision != null;
       store.savePendingDecision({
         id: event.decision.request_id,
         installationId: installation.id,
@@ -173,9 +186,13 @@ async function route(request, response) {
         question: event.decision.question,
         choices: event.decision.choices,
         questions: event.decision.questions,
-        deliverable: shouldDeliver(installation.preferences, event.type)
-          && installation.preferences.decision_cards !== false,
+        deliverable,
       });
+      if (!deliverable) return sendJson(response, 202, { accepted: true, delivered: false });
+      const result = await apns.send(installation.deviceToken, notification);
+      if (result.status === 410 || result.reason === 'BadDeviceToken' || result.reason === 'Unregistered') store.deactivateInstallation(installation.id);
+      if (!result.ok) return sendJson(response, 502, { error: 'apns_rejected', reason: result.reason, status: result.status });
+      return sendJson(response, 202, { accepted: true, delivered: true });
     }
     if (!shouldDeliver(installation.preferences, event.type)) return sendJson(response, 202, { accepted: true, delivered: false });
     const notification = notificationFor(event, installation.preferences);
@@ -186,7 +203,10 @@ async function route(request, response) {
   }
 
   // ── Clarify answer loop ──────────────────────────────────────────────
-  const decisionMatch = url.pathname.match(/^\/v1\/decisions\/([A-Za-z0-9_-]{4,128})$/);
+  // The device answer route is /v1/decisions/{id}/respond (the iOS client's
+  // contract); the bare /v1/decisions/{id} POST path is kept as a
+  // backward-compatible alias. Both run the same handler.
+  const decisionMatch = url.pathname.match(/^\/v1\/decisions\/([A-Za-z0-9_-]{4,128})(\/respond)?$/);
   if (decisionMatch && request.method === 'POST') {
     // The device that received the push answers by the plugin-minted id.
     // Authenticate and rate-limit before reading the body: this endpoint is
@@ -208,12 +228,18 @@ async function route(request, response) {
     const questionId = cleanText(body.question_id, 40);
     const result = store.respondPendingDecision(installation.id, id, answer, questionId);
     if (result.outcome === 'unknown') return sendJson(response, 404, { error: 'unknown_decision' });
+    // Distinct device-facing outcomes: a duplicate qid settles only that
+    // question as answered elsewhere (409), while a RELEASED decision means
+    // Hermes resolved through another surface and the whole pushed card must
+    // be torn down (410). Collapsing them would either strand open qids or
+    // clear a card that still has answerable questions.
+    if (result.outcome === 'released') return sendJson(response, 410, { error: 'decision_released' });
     if (result.outcome === 'already_answered') return sendJson(response, 409, { error: 'already_answered' });
     const payload = { status: 'answered' };
     if (Array.isArray(result.remaining)) payload.remaining = result.remaining;
     return sendJson(response, 200, payload);
   }
-  if (decisionMatch && request.method === 'GET') {
+  if (decisionMatch && decisionMatch[2] === undefined && request.method === 'GET') {
     // The gateway polls for the answer while its clarify middleware blocks.
     const credential = gatewayCredential(request);
     if (!credential || !store.authenticateGateway(credential.installationId, credential.gatewayId, credential.secret)) return sendJson(response, 401, { error: 'unauthorized' });
@@ -221,10 +247,11 @@ async function route(request, response) {
     const status = store.pendingDecisionStatus(credential.installationId, credential.gatewayId, decisionMatch[1]);
     return sendJson(response, 200, status);
   }
-  if (decisionMatch && request.method === 'DELETE') {
+  if (decisionMatch && decisionMatch[2] === undefined && request.method === 'DELETE') {
     // The plugin releases a parked decision when the original clarify path
     // won the race or its poll budget fell back to it: a late device answer
-    // must then be rejected (409) instead of parking a result nobody reads.
+    // must then be rejected (410 decision_released) instead of parking a
+    // result nobody reads.
     const credential = gatewayCredential(request);
     if (!credential || !store.authenticateGateway(credential.installationId, credential.gatewayId, credential.secret)) return sendJson(response, 401, { error: 'unauthorized' });
     enforceRateLimit(`decision-poll:${credential.gatewayId}`, 120, 60_000);
@@ -413,7 +440,19 @@ function validateDecision(value, eventType) {
       .map((choice) => cleanText(choice, 80))
       .filter((choice) => choice !== undefined)
       .slice(0, 8);
-    return { kind: 'clarify', request_id: requestId, question, ...(choices.length ? { choices } : {}) };
+    // Batch decisions (plugin 0.3+) carry the FULL question set. It MUST
+    // survive this boundary through the same shared sanitizer the
+    // pending-decision store uses — dropping it here would silently reduce
+    // every pushed batch to its collapsed first question. Deduplication and
+    // bounds are inside the shared sanitizer.
+    const questions = sanitizeBatchQuestions(value.questions);
+    return {
+      kind: 'clarify',
+      request_id: requestId,
+      question,
+      ...(choices.length ? { choices } : {}),
+      ...(questions.length ? { questions } : {}),
+    };
   }
   return undefined;
 }

--- a/relay/src/server.mjs
+++ b/relay/src/server.mjs
@@ -243,7 +243,16 @@ async function route(request, response) {
     }
     if (!shouldDeliver(installation.preferences, event.type)) return sendJson(response, 202, { accepted: true, delivered: false });
     const notification = notificationFor(event, installation.preferences);
-    const result = await apnsSend(installation.deviceToken, notification);
+    let result;
+    try {
+      result = await apnsSend(installation.deviceToken, notification);
+    } catch (error) {
+      // Same contract as the decision path: a THROWN transport failure is
+      // reported upstream, never left to surface as a 500. There is no
+      // parked decision on this path, so there is nothing to flip.
+      console.error(JSON.stringify({ level: 'error', message: 'apns send threw', error: error instanceof Error ? error.message : String(error) }));
+      return sendJson(response, 502, { error: 'apns_unreachable' });
+    }
     if (result.status === 410 || result.reason === 'BadDeviceToken' || result.reason === 'Unregistered') store.deactivateInstallation(installation.id);
     if (!result.ok) return sendJson(response, 502, { error: 'apns_rejected', reason: result.reason, status: result.status });
     return sendJson(response, 202, { accepted: true, delivered: true });
@@ -597,6 +606,13 @@ function readConfig() {
   for (const name of required) if (!process.env[name]) throw new Error(`${name} is required.`);
   const publicUrl = new URL(process.env.PUBLIC_URL);
   if (publicUrl.protocol !== 'https:') throw new Error('PUBLIC_URL must use HTTPS.');
+  let apnsOrigin;
+  if (process.env.APNS_ORIGIN !== undefined) {
+    // Fail at boot, not on the first real send: a mistyped origin would
+    // otherwise silently turn every push into a 502 until someone notices.
+    apnsOrigin = new URL(process.env.APNS_ORIGIN);
+    if (apnsOrigin.protocol !== 'https:') throw new Error('APNS_ORIGIN must use HTTPS.');
+  }
   return {
     host: process.env.HOST || '127.0.0.1',
     port: Number(process.env.PORT || 9120),
@@ -610,7 +626,7 @@ function readConfig() {
     // REAL transport: pointing it at a closed port exercises the actual
     // ClientHttp2Session failure path end to end, which the APNS_MODE seams
     // (they bypass ApnsClient entirely) cannot.
-    origin: process.env.APNS_ORIGIN,
+    origin: apnsOrigin,
     trustProxy: process.env.TRUST_PROXY === '1',
   };
 }

--- a/relay/src/server.mjs
+++ b/relay/src/server.mjs
@@ -309,6 +309,11 @@ async function route(request, response) {
     enforceRateLimit(`decision-cancel:${credential.gatewayId}`, 30, 60_000);
     const outcome = store.cancelPendingDecision(credential.installationId, credential.gatewayId, decisionMatch[1]);
     if (outcome === 'unknown') return sendJson(response, 404, { error: 'unknown_decision' });
+    // Diagnostic distinction only (same 200, Conduit never parses this
+    // body): an already-completed decision was never released — it was
+    // answered or completed on its own — and gateway logs should be able to
+    // tell that apart from a live release.
+    if (outcome === 'answered') return sendJson(response, 200, { status: 'already_completed' });
     return sendJson(response, 200, { status: 'cancelled' });
   }
 
@@ -601,6 +606,11 @@ function readConfig() {
     keyId: process.env.APNS_KEY_ID,
     teamId: process.env.APNS_TEAM_ID,
     topic: process.env.APNS_TOPIC,
+    // Optional origin override (default: production APNs). Test seam for the
+    // REAL transport: pointing it at a closed port exercises the actual
+    // ClientHttp2Session failure path end to end, which the APNS_MODE seams
+    // (they bypass ApnsClient entirely) cannot.
+    origin: process.env.APNS_ORIGIN,
     trustProxy: process.env.TRUST_PROXY === '1',
   };
 }

--- a/relay/src/server.mjs
+++ b/relay/src/server.mjs
@@ -20,6 +20,7 @@ let config;
 let store;
 let apns;
 let limits;
+let apnsSend;
 
 // APNs hard-caps a notification payload at 4096 bytes; stay under it with
 // headroom for JSON escaping and delivery headers, dropping decision content
@@ -31,6 +32,17 @@ function main() {
   store = new RelayStore(config.dataPath);
   apns = new ApnsClient(config);
   limits = new Map();
+  // Test seam: APNS_MODE=accept makes every send succeed and APNS_MODE=reject
+  // makes every send fail with a 403 — both without touching the network —
+  // so the e2e suite can exercise delivery outcomes, decision parking, and
+  // APNs-failure cleanup deterministically. Unset = real APNs.
+  if (process.env.APNS_MODE === 'accept') {
+    apnsSend = async () => ({ ok: true, status: 200, reason: null });
+  } else if (process.env.APNS_MODE === 'reject') {
+    apnsSend = async () => ({ ok: false, status: 403, reason: 'InvalidProviderToken' });
+  } else {
+    apnsSend = (deviceToken, notification) => apns.send(deviceToken, notification);
+  }
 
   const server = createServer(async (request, response) => {
     const startedAt = Date.now();
@@ -164,39 +176,56 @@ async function route(request, response) {
     // re-delivered event can never overwrite (and wipe the answer of) the
     // already-parked decision.
     //
-    // `deliverable` must reflect whether the device will actually receive an
-    // ANSWERABLE card, so the final notification is built first and the flag
-    // is taken from what survived into the APNs payload: device preferences
-    // (input.needed / decision_cards) and the 4 KB size guard can each strip
-    // the structured decision. Marking a decision deliverable when its card
-    // was stripped would make the plugin poll — and a widget-less device
-    // answer — a decision no card can reach.
+    // Two independent concepts must not be conflated:
+    //
+    //   notification_delivery  — did the user get the (plain or card-bearing)
+    //                            input.needed banner? Governed by the
+    //                            ordinary input.needed preference.
+    //   relay_decision_deliverability (`deliverable`) — does the delivered
+    //                            payload contain an ANSWERABLE structured
+    //                            card? Governed by decision_cards preference
+    //                            and the APNs size guard.
+    //
+    // The final notification is built first and `deliverable` is taken from
+    // what survived into the APNs payload. A decision whose card was stripped
+    // (preference or size guard) still sends the plain banner and is parked
+    // undeliverable, so the plugin stops relay-polling and falls back to
+    // Hermes' native clarify path — it never suppresses the ordinary
+    // notification.
+    let parkedDecisionId = null;
     if (event.decision?.kind === 'clarify' && event.decision.request_id) {
+      parkedDecisionId = event.decision.request_id;
       const deliverableBase = shouldDeliver(installation.preferences, event.type);
       const notification = deliverableBase
         ? notificationFor(event, installation.preferences)
         : null;
       const decisionInPayload = notification?.payload?.conduit?.decision;
-      const deliverable = decisionInPayload != null
+      const decisionDeliverable = decisionInPayload != null
         && notification?.payload?.body?.conduit?.decision != null;
       store.savePendingDecision({
-        id: event.decision.request_id,
+        id: parkedDecisionId,
         installationId: installation.id,
         gatewayId: credential.gatewayId,
         question: event.decision.question,
         choices: event.decision.choices,
         questions: event.decision.questions,
-        deliverable,
+        deliverable: decisionDeliverable,
       });
-      if (!deliverable) return sendJson(response, 202, { accepted: true, delivered: false });
-      const result = await apns.send(installation.deviceToken, notification);
+      if (!notification) return sendJson(response, 202, { accepted: true, delivered: false });
+      const result = await apnsSend(installation.deviceToken, notification);
       if (result.status === 410 || result.reason === 'BadDeviceToken' || result.reason === 'Unregistered') store.deactivateInstallation(installation.id);
-      if (!result.ok) return sendJson(response, 502, { error: 'apns_rejected', reason: result.reason, status: result.status });
+      if (!result.ok) {
+        // The answerable card never reached the device: flip the parked
+        // decision to undeliverable so the plugin's next poll falls back to
+        // the native clarify path instead of waiting out the budget.
+        store.markPendingDecisionUndeliverable(installation.id, credential.gatewayId, parkedDecisionId);
+        return sendJson(response, 502, { error: 'apns_rejected', reason: result.reason, status: result.status });
+      }
       return sendJson(response, 202, { accepted: true, delivered: true });
     }
     if (!shouldDeliver(installation.preferences, event.type)) return sendJson(response, 202, { accepted: true, delivered: false });
     const notification = notificationFor(event, installation.preferences);
-    const result = await apns.send(installation.deviceToken, notification);
+    const result = await apnsSend(installation.deviceToken, notification);
     if (result.status === 410 || result.reason === 'BadDeviceToken' || result.reason === 'Unregistered') store.deactivateInstallation(installation.id);
     if (!result.ok) return sendJson(response, 502, { error: 'apns_rejected', reason: result.reason, status: result.status });
     return sendJson(response, 202, { accepted: true, delivered: true });
@@ -228,6 +257,9 @@ async function route(request, response) {
     const questionId = cleanText(body.question_id, 40);
     const result = store.respondPendingDecision(installation.id, id, answer, questionId);
     if (result.outcome === 'unknown') return sendJson(response, 404, { error: 'unknown_decision' });
+    // Distinct from 404: the decision is live but the sender addressed a qid
+    // it does not contain — the request is malformed, not the decision gone.
+    if (result.outcome === 'invalid_question') return sendJson(response, 400, { error: 'invalid_question_id' });
     // Distinct device-facing outcomes: a duplicate qid settles only that
     // question as answered elsewhere (409), while a RELEASED decision means
     // Hermes resolved through another surface and the whole pushed card must

--- a/relay/src/server.mjs
+++ b/relay/src/server.mjs
@@ -172,6 +172,7 @@ async function route(request, response) {
         gatewayId: credential.gatewayId,
         question: event.decision.question,
         choices: event.decision.choices,
+        questions: event.decision.questions,
         deliverable: shouldDeliver(installation.preferences, event.type)
           && installation.preferences.decision_cards !== false,
       });
@@ -201,10 +202,16 @@ async function route(request, response) {
     const body = await readJson(request);
     const answer = cleanText(body.answer, 2000);
     if (!answer) return sendJson(response, 400, { error: 'invalid_answer' });
-    const outcome = store.respondPendingDecision(installation.id, id, answer);
-    if (outcome === 'unknown') return sendJson(response, 404, { error: 'unknown_decision' });
-    if (outcome === 'already_answered') return sendJson(response, 409, { error: 'already_answered' });
-    return sendJson(response, 200, { status: 'answered' });
+    // question_id scopes the answer to ONE question of a batch decision
+    // (first-answer-wins per qid, other qids stay open); its absence keeps
+    // the legacy whole-decision shape for single-question cards.
+    const questionId = cleanText(body.question_id, 40);
+    const result = store.respondPendingDecision(installation.id, id, answer, questionId);
+    if (result.outcome === 'unknown') return sendJson(response, 404, { error: 'unknown_decision' });
+    if (result.outcome === 'already_answered') return sendJson(response, 409, { error: 'already_answered' });
+    const payload = { status: 'answered' };
+    if (Array.isArray(result.remaining)) payload.remaining = result.remaining;
+    return sendJson(response, 200, payload);
   }
   if (decisionMatch && request.method === 'GET') {
     // The gateway polls for the answer while its clarify middleware blocks.
@@ -213,6 +220,17 @@ async function route(request, response) {
     enforceRateLimit(`decision-poll:${credential.gatewayId}`, 120, 60_000);
     const status = store.pendingDecisionStatus(credential.installationId, credential.gatewayId, decisionMatch[1]);
     return sendJson(response, 200, status);
+  }
+  if (decisionMatch && request.method === 'DELETE') {
+    // The plugin releases a parked decision when the original clarify path
+    // won the race or its poll budget fell back to it: a late device answer
+    // must then be rejected (409) instead of parking a result nobody reads.
+    const credential = gatewayCredential(request);
+    if (!credential || !store.authenticateGateway(credential.installationId, credential.gatewayId, credential.secret)) return sendJson(response, 401, { error: 'unauthorized' });
+    enforceRateLimit(`decision-poll:${credential.gatewayId}`, 120, 60_000);
+    const outcome = store.cancelPendingDecision(credential.installationId, credential.gatewayId, decisionMatch[1]);
+    if (outcome === 'unknown') return sendJson(response, 404, { error: 'unknown_decision' });
+    return sendJson(response, 200, { status: 'cancelled' });
   }
 
   if (request.method === 'DELETE' && url.pathname === '/v1/gateways/current') {

--- a/relay/src/store.mjs
+++ b/relay/src/store.mjs
@@ -307,14 +307,21 @@ export class RelayStore {
   // deliverable decision was parked: no device received the answerable
   // card, so the next plugin poll must see deliverable:false and fall back
   // to the native clarify path instead of waiting out the poll budget.
-  // Already-answered and already-released decisions are left untouched.
+  // Released and fully completed decisions (scalar or batch) are never
+  // mutated — their outcomes are already settled.
   markPendingDecisionUndeliverable(installationId, gatewayId, id) {
     this.prune();
     const decision = this.data.pendingDecisions[id];
     if (!decision || decision.installationId !== installationId || decision.gatewayId !== gatewayId) {
       return 'unknown';
     }
-    if (decision.cancelledAt || decision.answer !== undefined) return 'skipped';
+    // pendingDecisionStatus reports 'answered' for BOTH a completed scalar
+    // decision (decision.answer set) and a completed batch (every qid
+    // locked) — one guard covers both shapes.
+    if (this.pendingDecisionStatus(installationId, gatewayId, id).status === 'answered') {
+      return 'skipped';
+    }
+    if (decision.cancelledAt) return 'skipped';
     decision.deliverable = false;
     this.save();
     return 'marked';

--- a/relay/src/store.mjs
+++ b/relay/src/store.mjs
@@ -349,7 +349,9 @@ export function normalizePreferences(value = {}) {
 }
 
 // Batch decision bounds — mirror the plugin's sanitizer so a malformed push
-// can never park an oversized batch.
+// can never park an oversized batch. Protocol/store maximum only: an
+// answerable card is further bounded by the APNs 4 KB payload guard, and a
+// batch that exceeds it degrades to the plain banner (deliverable=false).
 export const MAX_BATCH_QUESTIONS = 8;
 export const MAX_BATCH_CHOICES = 8;
 

--- a/relay/src/store.mjs
+++ b/relay/src/store.mjs
@@ -190,10 +190,12 @@ export class RelayStore {
       gatewayId,
       question: String(question ?? ''),
       choices: Array.isArray(choices) ? choices.map(String) : [],
-      // Bounds mirror the plugin's sanitizer: a malformed push must never
-      // park an oversized or malformed batch.
+      // Shared sanitizer (also applied at the relay trust boundary): a
+      // malformed push must never park an oversized or malformed batch.
       questions: sanitizeBatchQuestions(questions),
-      answers: {},
+      // Null prototype: answer maps are keyed by qid, and a qid like
+      // "__proto__" must never reach Object.prototype pollution paths.
+      answers: Object.create(null),
       // False when device preferences mean no card was shown; the gateway's
       // poller stops early instead of polling a decision nobody can answer.
       deliverable: Boolean(deliverable),
@@ -212,23 +214,30 @@ export class RelayStore {
     this.prune();
     const decision = this.data.pendingDecisions[id];
     if (!decision || decision.installationId !== installationId) return { outcome: 'unknown' };
-    // A released decision (the original gateway path won and cancelled it)
-    // rejects late device answers instead of parking a result nobody reads.
-    if (decision.cancelledAt || decision.answer !== undefined) return { outcome: 'already_answered' };
+    // Distinct device-facing outcomes: a CANCELLED decision (the original
+    // gateway path won) releases the whole pushed card (410
+    // decision_released), while an already-answered decision stays a 409
+    // (answered elsewhere). Collapsing them would clear cards that still
+    // have answerable questions.
+    if (decision.cancelledAt) return { outcome: 'released' };
+    if (decision.answer !== undefined) return { outcome: 'already_answered' };
     const batchQuestions = Array.isArray(decision.questions) ? decision.questions : [];
     if (batchQuestions.length) {
-      decision.answers ??= {};
+      decision.answers ??= Object.create(null);
+      const answers = decision.answers;
       // A question_id targets one qid of the batch; without one, the sender
       // is a pre-batch device answering the collapsed first-question card.
       const target = questionId || batchQuestions[0].qid;
       if (!batchQuestions.some((question) => question.qid === target)) {
         return { outcome: 'unknown' };
       }
-      if (decision.answers[target] !== undefined) return { outcome: 'already_answered' };
-      decision.answers[target] = String(answer ?? '').slice(0, 2000);
+      // hasOwn, not truthiness: a stored "" answer must still read as
+      // locked, and sanitized qids can never collide with Object.prototype.
+      if (Object.hasOwn(answers, target)) return { outcome: 'already_answered' };
+      answers[target] = String(answer ?? '').slice(0, 2000);
       decision.answeredAt = Date.now();
       const remaining = batchQuestions.map((question) => question.qid)
-        .filter((qid) => decision.answers[qid] === undefined);
+        .filter((qid) => !Object.hasOwn(answers, qid));
       this.save();
       return { outcome: 'answered', remaining };
     }
@@ -253,7 +262,7 @@ export class RelayStore {
     if (batchQuestions.length) {
       const answers = decision.answers ?? {};
       const remaining = batchQuestions.map((question) => question.qid)
-        .filter((qid) => answers[qid] === undefined);
+        .filter((qid) => !Object.hasOwn(answers, qid));
       if (remaining.length === 0) {
         return { status: 'answered', answers, remaining: [] };
       }
@@ -313,27 +322,49 @@ export function normalizePreferences(value = {}) {
 }
 
 // Batch decision bounds — mirror the plugin's sanitizer so a malformed push
-// can never park an oversized batch. One malformed entry is dropped rather
-// than failing the whole decision.
-const MAX_BATCH_QUESTIONS = 8;
-const MAX_BATCH_CHOICES = 8;
+// can never park an oversized batch.
+export const MAX_BATCH_QUESTIONS = 8;
+export const MAX_BATCH_CHOICES = 8;
 
-function sanitizeBatchQuestions(value) {
+// Single shared batch sanitizer for BOTH trust boundaries (the /v1/events
+// decision validation and the pending-decision store) so the notification
+// payload, the stored decision, and the poll answers can never disagree
+// about what a batch contains. Output is the WIRE shape (snake_case
+// multi_select — this array is embedded in APNs payloads verbatim). One
+// malformed entry is dropped rather than failing the whole decision; a
+// valid remainder survives. Deduplicates qids (first occurrence wins) and
+// repeated choice values.
+const UNSAFE_QIDS = new Set(['__proto__', 'constructor', 'prototype']);
+
+export function sanitizeBatchQuestions(value) {
   if (!Array.isArray(value)) return [];
   const questions = [];
+  const seenQids = new Set();
   for (const entry of value.slice(0, MAX_BATCH_QUESTIONS)) {
     if (!entry || typeof entry !== 'object') continue;
     const qid = String(entry.qid ?? '').trim().slice(0, 40);
+    // Gateway-minted qids are `q<index>`; this charset plus the reserved-name
+    // rejection keeps answer maps prototype-safe and per-question respond
+    // targets unambiguous.
+    if (!/^[A-Za-z0-9_-]+$/.test(qid) || UNSAFE_QIDS.has(qid) || seenQids.has(qid)) continue;
     const question = String(entry.question ?? '').trim().slice(0, 500);
-    if (!qid || !question) continue;
+    if (!question) continue;
+    const seenChoices = new Set();
+    const choices = (Array.isArray(entry.choices) ? entry.choices : [])
+      .map((choice) => String(choice ?? '').trim().slice(0, 80))
+      .filter((choice) => {
+        if (!choice || seenChoices.has(choice)) return false;
+        seenChoices.add(choice);
+        return true;
+      })
+      .slice(0, MAX_BATCH_CHOICES);
     questions.push({
       qid,
       question,
-      choices: Array.isArray(entry.choices)
-        ? entry.choices.map((choice) => String(choice).trim().slice(0, 80)).filter(Boolean).slice(0, MAX_BATCH_CHOICES)
-        : [],
-      multiSelect: entry.multi_select === true,
+      choices,
+      multi_select: entry.multi_select === true,
     });
+    seenQids.add(qid);
   }
   return questions;
 }

--- a/relay/src/store.mjs
+++ b/relay/src/store.mjs
@@ -173,8 +173,13 @@ export class RelayStore {
   // device answers by that id; the plugin polls for the answer while its
   // middleware blocks the tool call. Approval decisions answer via the
   // gateway directly and never enter this store.
+  //
+  // Batch decisions (plugin 0.3+) additionally carry `questions` — the full
+  // gateway question set with qids. Answers accumulate PER QUESTION with
+  // first-answer-wins per qid, and the decision completes only when every
+  // qid is locked, so background batch clarifies preserve the whole batch.
 
-  savePendingDecision({ id, installationId, gatewayId, question, choices, deliverable = true }) {
+  savePendingDecision({ id, installationId, gatewayId, question, choices, questions, deliverable = true }) {
     this.prune();
     // uuid4-minted ids make collisions vanishingly unlikely, but never let a
     // same-id write from another installation clobber a parked decision.
@@ -185,6 +190,10 @@ export class RelayStore {
       gatewayId,
       question: String(question ?? ''),
       choices: Array.isArray(choices) ? choices.map(String) : [],
+      // Bounds mirror the plugin's sanitizer: a malformed push must never
+      // park an oversized or malformed batch.
+      questions: sanitizeBatchQuestions(questions),
+      answers: {},
       // False when device preferences mean no card was shown; the gateway's
       // poller stops early instead of polling a decision nobody can answer.
       deliverable: Boolean(deliverable),
@@ -199,15 +208,34 @@ export class RelayStore {
     this.save();
   }
 
-  respondPendingDecision(installationId, id, answer) {
+  respondPendingDecision(installationId, id, answer, questionId = '') {
     this.prune();
     const decision = this.data.pendingDecisions[id];
-    if (!decision || decision.installationId !== installationId) return 'unknown';
-    if (decision.answer !== undefined) return 'already_answered';
+    if (!decision || decision.installationId !== installationId) return { outcome: 'unknown' };
+    // A released decision (the original gateway path won and cancelled it)
+    // rejects late device answers instead of parking a result nobody reads.
+    if (decision.cancelledAt || decision.answer !== undefined) return { outcome: 'already_answered' };
+    const batchQuestions = Array.isArray(decision.questions) ? decision.questions : [];
+    if (batchQuestions.length) {
+      decision.answers ??= {};
+      // A question_id targets one qid of the batch; without one, the sender
+      // is a pre-batch device answering the collapsed first-question card.
+      const target = questionId || batchQuestions[0].qid;
+      if (!batchQuestions.some((question) => question.qid === target)) {
+        return { outcome: 'unknown' };
+      }
+      if (decision.answers[target] !== undefined) return { outcome: 'already_answered' };
+      decision.answers[target] = String(answer ?? '').slice(0, 2000);
+      decision.answeredAt = Date.now();
+      const remaining = batchQuestions.map((question) => question.qid)
+        .filter((qid) => decision.answers[qid] === undefined);
+      this.save();
+      return { outcome: 'answered', remaining };
+    }
     decision.answer = String(answer ?? '').slice(0, 2000);
     decision.answeredAt = Date.now();
     this.save();
-    return 'answered';
+    return { outcome: 'answered' };
   }
 
   pendingDecisionStatus(installationId, gatewayId, id) {
@@ -216,12 +244,51 @@ export class RelayStore {
     if (!decision || decision.installationId !== installationId || decision.gatewayId !== gatewayId) {
       return { status: 'unknown' };
     }
+    if (decision.cancelledAt) {
+      // Released by the gateway: the poller treats this like expiry and
+      // falls back to the original clarify path.
+      return { status: 'unknown' };
+    }
+    const batchQuestions = Array.isArray(decision.questions) ? decision.questions : [];
+    if (batchQuestions.length) {
+      const answers = decision.answers ?? {};
+      const remaining = batchQuestions.map((question) => question.qid)
+        .filter((qid) => answers[qid] === undefined);
+      if (remaining.length === 0) {
+        return { status: 'answered', answers, remaining: [] };
+      }
+      return {
+        status: 'pending',
+        // Legacy records predate the flag; treat missing as deliverable so
+        // the poller's behavior is unchanged for decisions parked by older
+        // relays.
+        deliverable: decision.deliverable !== false,
+        remaining,
+        answers,
+      };
+    }
     if (decision.answer === undefined) {
-      // Legacy records predate the flag; treat missing as deliverable so the
-      // poller's behavior is unchanged for decisions parked by older relays.
       return { status: 'pending', deliverable: decision.deliverable !== false };
     }
     return { status: 'answered', answer: decision.answer };
+  }
+
+  // Called by the plugin when the original clarify path won the race or the
+  // poll budget fell back to it: late device answers must be rejected (409)
+  // rather than parked as results nobody will read. Cancelling an
+  // already-completed decision reports it instead of double-marking.
+  cancelPendingDecision(installationId, gatewayId, id) {
+    this.prune();
+    const decision = this.data.pendingDecisions[id];
+    if (!decision || decision.installationId !== installationId || decision.gatewayId !== gatewayId) {
+      return 'unknown';
+    }
+    if (this.pendingDecisionStatus(installationId, gatewayId, id).status === 'answered') {
+      return 'answered';
+    }
+    decision.cancelledAt = Date.now();
+    this.save();
+    return 'cancelled';
   }
 
   prune() {
@@ -243,6 +310,32 @@ export class RelayStore {
 
 export function normalizePreferences(value = {}) {
   return Object.fromEntries(Object.entries(defaultPreferences).map(([key, fallback]) => [key, typeof value[key] === 'boolean' ? value[key] : fallback]));
+}
+
+// Batch decision bounds — mirror the plugin's sanitizer so a malformed push
+// can never park an oversized batch. One malformed entry is dropped rather
+// than failing the whole decision.
+const MAX_BATCH_QUESTIONS = 8;
+const MAX_BATCH_CHOICES = 8;
+
+function sanitizeBatchQuestions(value) {
+  if (!Array.isArray(value)) return [];
+  const questions = [];
+  for (const entry of value.slice(0, MAX_BATCH_QUESTIONS)) {
+    if (!entry || typeof entry !== 'object') continue;
+    const qid = String(entry.qid ?? '').trim().slice(0, 40);
+    const question = String(entry.question ?? '').trim().slice(0, 500);
+    if (!qid || !question) continue;
+    questions.push({
+      qid,
+      question,
+      choices: Array.isArray(entry.choices)
+        ? entry.choices.map((choice) => String(choice).trim().slice(0, 80)).filter(Boolean).slice(0, MAX_BATCH_CHOICES)
+        : [],
+      multiSelect: entry.multi_select === true,
+    });
+  }
+  return questions;
 }
 
 function publicInstallation(installation) {

--- a/relay/src/store.mjs
+++ b/relay/src/store.mjs
@@ -228,8 +228,11 @@ export class RelayStore {
       // A question_id targets one qid of the batch; without one, the sender
       // is a pre-batch device answering the collapsed first-question card.
       const target = questionId || batchQuestions[0].qid;
+      // An unknown qid on a live decision is the sender's mistake, not a
+      // missing decision — surfaced as its own outcome so the device gets
+      // 400 invalid_question_id instead of a misleading 404.
       if (!batchQuestions.some((question) => question.qid === target)) {
-        return { outcome: 'unknown' };
+        return { outcome: 'invalid_question' };
       }
       // hasOwn, not truthiness: a stored "" answer must still read as
       // locked, and sanitized qids can never collide with Object.prototype.
@@ -298,6 +301,23 @@ export class RelayStore {
     decision.cancelledAt = Date.now();
     this.save();
     return 'cancelled';
+  }
+
+  // Called by the relay intake when APNs rejected the send AFTER a
+  // deliverable decision was parked: no device received the answerable
+  // card, so the next plugin poll must see deliverable:false and fall back
+  // to the native clarify path instead of waiting out the poll budget.
+  // Already-answered and already-released decisions are left untouched.
+  markPendingDecisionUndeliverable(installationId, gatewayId, id) {
+    this.prune();
+    const decision = this.data.pendingDecisions[id];
+    if (!decision || decision.installationId !== installationId || decision.gatewayId !== gatewayId) {
+      return 'unknown';
+    }
+    if (decision.cancelledAt || decision.answer !== undefined) return 'skipped';
+    decision.deliverable = false;
+    this.save();
+    return 'marked';
   }
 
   prune() {

--- a/relay/test/apns.test.mjs
+++ b/relay/test/apns.test.mjs
@@ -1,0 +1,131 @@
+import { strict as assert } from 'node:assert';
+import { generateKeyPairSync } from 'node:crypto';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { createServer as createNetServer } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createServer as createHttp2Server } from 'node:http2';
+import { after, before, test } from 'node:test';
+
+import { ApnsClient } from '../src/apns.mjs';
+
+// Transport-level tests for the REAL ApnsClient — no APNS_MODE stub, no
+// mocking of send(). The APNS_MODE seams bypass ApnsClient entirely, so a
+// connection-level ClientHttp2Session failure (the shape that used to crash
+// the whole relay as an unhandled 'error' event) was never exercised. Here
+// the client talks to actual endpoints: a released loopback port (real
+// connection refusal → session 'error') and a real local HTTP/2 server
+// (success and APNs-style rejection responses).
+
+const dir = mkdtempSync(join(tmpdir(), 'conduit-apns-'));
+const keyPath = join(dir, 'ephemeral-key.pem');
+const { privateKey } = generateKeyPairSync('ec', { namedCurve: 'P-256' });
+writeFileSync(keyPath, privateKey.export({ type: 'sec1', format: 'pem' }));
+
+after(() => rmSync(dir, { recursive: true, force: true }));
+
+function client(origin) {
+  return new ApnsClient({ keyPath, keyId: 'AAAAAAAAAA', teamId: 'BBBBBBBBBB', topic: 'com.milim.relay', origin });
+}
+
+const notification = { payload: { aps: { alert: { title: 't', body: 'b' } } } };
+
+// Reserve a loopback port and release it: connecting there must be refused,
+// which surfaces as a genuine session-level 'error' inside http2.connect.
+function closedPort() {
+  return new Promise((resolve, reject) => {
+    const probe = createNetServer();
+    probe.listen(0, '127.0.0.1', () => {
+      const port = probe.address().port;
+      probe.close(() => resolve(port));
+    });
+    probe.on('error', reject);
+  });
+}
+
+function startH2Server(handler) {
+  return new Promise((resolve, reject) => {
+    const server = createHttp2Server();
+    server.on('stream', handler);
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => resolve({ server, origin: `http://127.0.0.1:${server.address().port}` }));
+  });
+}
+
+test('a real connection-level session error rejects send() exactly once and the process survives', async () => {
+  const { server, origin } = await startH2Server((stream) => {
+    // Accept the stream, then tear the SERVER session down ungracefully
+    // while the request is in flight (destroying the h2 session, NOT the
+    // raw socket — Node forbids socket manipulation through a live session).
+    // The client sees BOTH a stream error and a session error for this one
+    // send, which is exactly the double-settlement shape the settle-once
+    // guard exists for.
+    stream.session.destroy();
+  });
+  const apns = client(origin);
+  try {
+    await assert.rejects(
+      apns.send('a'.repeat(64), notification),
+      (error) => {
+        // The rejected promise is the ONLY failure surface the server sees;
+        // assert it is a real error, not a hang or a synthetic value.
+        assert.ok(error instanceof Error);
+        return true;
+      },
+    );
+    // Reaching this line at all is the regression proof: before the session
+    // 'error' handler existed, an unhandled 'error' event terminated the
+    // entire Node process. A second send proves the client and process are
+    // still healthy and settle-once did not wedge the promise machinery.
+    await assert.rejects(apns.send('b'.repeat(64), notification), Error);
+  } finally {
+    server.close();
+    server.closeAllConnections?.();
+  }
+});
+
+test('a refused connection surfaces as a rejected send() without crashing the process', async () => {
+  const port = await closedPort();
+  const apns = client(`https://127.0.0.1:${port}`);
+  await assert.rejects(apns.send('c'.repeat(64), notification), (error) => {
+    assert.ok(error instanceof Error);
+    return true;
+  });
+  // Still alive: another send against another dead port fails the same way.
+  const port2 = await closedPort();
+  await assert.rejects(client(`https://127.0.0.1:${port2}`).send('d'.repeat(64), notification), Error);
+});
+
+test('a real 200 APNs response resolves exactly once with ok:true', async () => {
+  const { server, origin } = await startH2Server((stream) => {
+    stream.respond({ ':status': 200, 'content-type': 'application/json' });
+    stream.end('{}');
+  });
+  try {
+    const result = await client(origin).send('e'.repeat(64), notification);
+    assert.deepEqual(result, { ok: true, status: 200, reason: null });
+  } finally {
+    server.close();
+    server.closeAllConnections?.();
+  }
+});
+
+test('a real APNs rejection response resolves with ok:false and the reason', async () => {
+  const { server, origin } = await startH2Server((stream) => {
+    stream.respond({ ':status': 403, 'content-type': 'application/json' });
+    stream.end(JSON.stringify({ reason: 'BadDeviceToken' }));
+  });
+  try {
+    const result = await client(origin).send('f'.repeat(64), notification);
+    assert.deepEqual(result, { ok: false, status: 403, reason: 'BadDeviceToken' });
+  } finally {
+    server.close();
+    server.closeAllConnections?.();
+  }
+});
+
+// Guard the default origin so the DI seam cannot silently change production.
+test('the default origin is production APNs', () => {
+  const apns = new ApnsClient({ keyPath, keyId: 'AAAAAAAAAA', teamId: 'BBBBBBBBBB', topic: 'com.milim.relay' });
+  assert.equal(apns.origin, 'https://api.push.apple.com');
+});

--- a/relay/test/decisions.e2e.test.mjs
+++ b/relay/test/decisions.e2e.test.mjs
@@ -881,12 +881,23 @@ test('a REAL APNs session failure parks the decision undeliverable and the relay
   assert.equal(poll.status, 200);
   assert.deepEqual(poll.json, { status: 'pending', deliverable: false });
 
-  // THE regression assertion: the session 'error' event must have been
-  // converted into the rejected send promise — an unhandled 'error' would
-  // have killed this process, and both of these requests would fail.
+  // Still alive: another poll works too, and a plain notification (no
+  // decision) takes the same thrown-transport path to 502.
   const health = await api(deadBaseUrl, '/healthz');
   assert.equal(health.status, 200);
   assert.deepEqual(health.json, { ok: true });
+  const plain = await api(deadBaseUrl, '/v1/events', {
+    method: 'POST',
+    credential: gatewayCredential,
+    body: {
+      type: 'response.ready',
+      event_id: 'response:deadapns01',
+      session_id: 'sess-dead',
+      profile: 'default',
+    },
+  });
+  assert.equal(plain.status, 502);
+  assert.equal(plain.json.error, 'apns_unreachable');
   const alivePoll = await api(deadBaseUrl, '/v1/decisions/conduit-push-dead1', { credential: gatewayCredential });
   assert.equal(alivePoll.status, 200);
 });

--- a/relay/test/decisions.e2e.test.mjs
+++ b/relay/test/decisions.e2e.test.mjs
@@ -18,10 +18,13 @@ import { after, before, test } from 'node:test';
 const dir = mkdtempSync(join(tmpdir(), 'conduit-relay-e2e-'));
 const port = 19000 + Math.floor(Math.random() * 1000);
 const rejectPort = port + 500;
+const throwPort = port + 1000;
 const baseUrl = `http://127.0.0.1:${port}`;
 const rejectBaseUrl = `http://127.0.0.1:${rejectPort}`;
+const throwBaseUrl = `http://127.0.0.1:${throwPort}`;
 const dataPath = join(dir, 'relay-data.json');
 const rejectDataPath = join(dir, 'relay-data-reject.json');
+const throwDataPath = join(dir, 'relay-data-throw.json');
 // The ApnsClient constructor parses the key eagerly, so the relay needs a
 // valid ES256 key to boot — an ephemeral one is fine; sends are stubbed by
 // APNS_MODE so nothing ever reaches Apple.
@@ -78,6 +81,7 @@ async function startRelay(aPort, apnsMode, dataFile) {
 before(async () => {
   children.push(await startRelay(port, 'accept', dataPath));
   children.push(await startRelay(rejectPort, 'reject', rejectDataPath));
+  children.push(await startRelay(throwPort, 'throw', throwDataPath));
 });
 
 after(() => {
@@ -628,4 +632,163 @@ test('unknown qid on a live batch decision is a bad request, not a missing decis
   // The established meanings are untouched: the live decision still polls.
   const poll = await api(baseUrl, '/v1/decisions/conduit-push-qidcheck', { credential: gatewayCredential });
   assert.equal(poll.json.status, 'pending');
+});
+
+test('an ordinary multi-question batch is delivered with the full qid set (single structured copy)', async () => {
+  // Representative 3-question batch (~200-char texts, 4 choices each) —
+  // large enough that the OLD duplicated payload flirted with the guard.
+  const registered = await api(baseUrl, '/v1/installations', {
+    method: 'POST',
+    body: {
+      bundle_id: 'com.milim.relay',
+      device_token: '1'.repeat(64),
+      environment: 'production',
+      preferences: { enabled: true, decision_cards: true },
+    },
+  });
+  assert.equal(registered.status, 201);
+  const deviceCredential = registered.json.credential;
+  const installationId = registered.json.installation.id;
+  const pairing = await api(baseUrl, `/v1/installations/${installationId}/pairings`, { method: 'POST', credential: deviceCredential });
+  const claimed = await api(baseUrl, '/v1/pairings/claim', {
+    method: 'POST',
+    body: { pairing_code: pairing.json.pairing_code, gateway_name: 'midsize gateway' },
+  });
+  const gatewayCredential = claimed.json.credential;
+
+  const longText = 'Describe this rollout step in detail: which services are affected, the expected downtime window, '
+    + 'the rollback procedure if validation fails, and who signs off on completion for the platform team to proceed. ';
+  const event = await api(baseUrl, '/v1/events', {
+    method: 'POST',
+    credential: gatewayCredential,
+    body: {
+      type: 'input.needed',
+      event_id: 'input:midsizee2e01',
+      session_id: 'sess-midsize-e2e',
+      profile: 'default',
+      decision: {
+        kind: 'clarify',
+        request_id: 'conduit-push-midsize1',
+        question: longText,
+        questions: [0, 1, 2].map((index) => ({
+          qid: `q${index}`,
+          question: longText + `Variant ${index}.`,
+          choices: [
+            `Proceed with option ${index} now`,
+            `Delay option ${index} to the next window`,
+            `Escalate option ${index} for review`,
+          ],
+          multi_select: index === 2,
+        })),
+      },
+    },
+  });
+  assert.equal(event.status, 202);
+  assert.deepEqual(event.json, { accepted: true, delivered: true });
+
+  const poll = await api(baseUrl, '/v1/decisions/conduit-push-midsize1', { credential: gatewayCredential });
+  assert.equal(poll.json.status, 'pending');
+  assert.equal(poll.json.deliverable, true, 'a representative batch must keep its answerable card');
+  assert.deepEqual(poll.json.remaining, ['q0', 'q1', 'q2'], 'all qids preserved');
+});
+
+test('APNs thrown transport error after parking flips the decision undeliverable', async () => {
+  const registered = await api(throwBaseUrl, '/v1/installations', {
+    method: 'POST',
+    body: {
+      bundle_id: 'com.milim.relay',
+      device_token: '9'.repeat(64),
+      environment: 'production',
+      preferences: { enabled: true, decision_cards: true },
+    },
+  });
+  assert.equal(registered.status, 201);
+  const deviceCredential = registered.json.credential;
+  const installationId = registered.json.installation.id;
+  const pairing = await api(throwBaseUrl, `/v1/installations/${installationId}/pairings`, { method: 'POST', credential: deviceCredential });
+  const claimed = await api(throwBaseUrl, '/v1/pairings/claim', {
+    method: 'POST',
+    body: { pairing_code: pairing.json.pairing_code, gateway_name: 'throw gateway' },
+  });
+  const gatewayCredential = claimed.json.credential;
+
+  const event = await api(throwBaseUrl, '/v1/events', {
+    method: 'POST',
+    credential: gatewayCredential,
+    body: {
+      type: 'input.needed',
+      event_id: 'input:throw000001',
+      session_id: 'sess-throw',
+      profile: 'default',
+      decision: {
+        kind: 'clarify',
+        request_id: 'conduit-push-throw1',
+        question: 'Which environment?',
+        questions: [{ qid: 'q0', question: 'Which environment?', choices: ['staging'], multi_select: false }],
+      },
+    },
+  });
+  // A thrown send is reported as a transport failure…
+  assert.equal(event.status, 502);
+  assert.equal(event.json.error, 'apns_unreachable');
+
+  // …and the parked decision is undeliverable, exactly like a returned
+  // rejection, so the plugin promptly falls back to the native path.
+  const poll = await api(throwBaseUrl, '/v1/decisions/conduit-push-throw1', { credential: gatewayCredential });
+  assert.equal(poll.json.status, 'pending');
+  assert.equal(poll.json.deliverable, false);
+});
+
+test('release succeeds even after the poll quota is exhausted', async () => {
+  const registered = await api(baseUrl, '/v1/installations', {
+    method: 'POST',
+    body: {
+      bundle_id: 'com.milim.relay',
+      device_token: '7'.repeat(64),
+      environment: 'production',
+      preferences: { enabled: false, decision_cards: true },
+    },
+  });
+  assert.equal(registered.status, 201);
+  const deviceCredential = registered.json.credential;
+  const installationId = registered.json.installation.id;
+  const pairing = await api(baseUrl, `/v1/installations/${installationId}/pairings`, { method: 'POST', credential: deviceCredential });
+  const claimed = await api(baseUrl, '/v1/pairings/claim', {
+    method: 'POST',
+    body: { pairing_code: pairing.json.pairing_code, gateway_name: 'quota gateway' },
+  });
+  const gatewayCredential = claimed.json.credential;
+  await api(baseUrl, '/v1/events', {
+    method: 'POST',
+    credential: gatewayCredential,
+    body: {
+      type: 'input.needed',
+      event_id: 'input:quota000001',
+      session_id: 'sess-quota',
+      profile: 'default',
+      decision: {
+        kind: 'clarify',
+        request_id: 'conduit-push-quota1',
+        question: 'One?',
+        questions: [{ qid: 'q0', question: 'One?', choices: ['a'], multi_select: false }],
+      },
+    },
+  });
+
+  // Burn the poll bucket (120/60s) plus margin — many polls will now 429.
+  for (let i = 0; i < 125; i += 1) {
+    await api(baseUrl, '/v1/decisions/conduit-push-quota1', { credential: gatewayCredential });
+  }
+
+  // Release must NOT be starved by the exhausted poll quota…
+  const released = await api(baseUrl, '/v1/decisions/conduit-push-quota1', { method: 'DELETE', credential: gatewayCredential });
+  assert.equal(released.status, 200);
+  // …and the late device answer still reports decision_released.
+  const late = await api(baseUrl, '/v1/decisions/conduit-push-quota1/respond', {
+    method: 'POST',
+    credential: deviceCredential,
+    body: { question_id: 'q0', answer: 'a' },
+  });
+  assert.equal(late.status, 410);
+  assert.equal(late.json.error, 'decision_released');
 });

--- a/relay/test/decisions.e2e.test.mjs
+++ b/relay/test/decisions.e2e.test.mjs
@@ -70,6 +70,156 @@ after(() => {
   rmSync(dir, { recursive: true, force: true });
 });
 
+test('batch clarify end to end: questions[] survive intake, per-qid answers, release, and both respond routes', async () => {
+  // Notifications ENABLED so intake builds the real APNs payload and
+  // deliverability is computed from what actually survived into it. The
+  // ephemeral key cannot pass Apple, so the send itself may 502 — the
+  // decision is parked (with accurate deliverability) before that point.
+  const registered = await api('/v1/installations', {
+    method: 'POST',
+    body: {
+      bundle_id: 'com.milim.relay',
+      device_token: 'c'.repeat(64),
+      environment: 'production',
+      preferences: { enabled: true, decision_cards: true },
+    },
+  });
+  assert.equal(registered.status, 201);
+  const deviceCredential = registered.json.credential;
+  const installationId = registered.json.installation.id;
+  const pairing = await api(`/v1/installations/${installationId}/pairings`, { method: 'POST', credential: deviceCredential });
+  const claimed = await api('/v1/pairings/claim', {
+    method: 'POST',
+    body: { pairing_code: pairing.json.pairing_code, gateway_name: 'batch gateway' },
+  });
+  const gatewayCredential = claimed.json.credential;
+
+  // Push a two-question batch through the real event endpoint.
+  const event = await api('/v1/events', {
+    method: 'POST',
+    credential: gatewayCredential,
+    body: {
+      type: 'input.needed',
+      event_id: 'input:batch0000001',
+      session_id: 'sess-batch',
+      profile: 'default',
+      decision: {
+        kind: 'clarify',
+        request_id: 'conduit-push-batche2e1',
+        question: 'Which environment?',
+        choices: ['staging', 'prod'],
+        questions: [
+          { qid: 'q0', question: 'Which environment?', choices: ['staging', 'prod'], multi_select: false },
+          { qid: 'q1', question: 'Which tests?', choices: ['unit', 'ui'], multi_select: true },
+        ],
+      },
+    },
+  });
+  // A decision card that survives the size guard attempts APNs; in tests the
+  // ephemeral key is rejected (502). The decision is parked either way.
+  assert.ok([202, 502].includes(event.status), `event status ${event.status}`);
+
+  // The stored decision kept the FULL batch, deliverable, and the open qids.
+  const poll = await api('/v1/decisions/conduit-push-batche2e1', { credential: gatewayCredential });
+  assert.equal(poll.status, 200);
+  assert.equal(poll.json.status, 'pending');
+  assert.equal(poll.json.deliverable, true, 'the card survived into the APNs payload');
+  assert.deepEqual(poll.json.remaining, ['q0', 'q1']);
+
+  // Device answers q0 through the iOS /respond route.
+  const q0 = await api('/v1/decisions/conduit-push-batche2e1/respond', {
+    method: 'POST',
+    credential: deviceCredential,
+    body: { question_id: 'q0', answer: 'staging' },
+  });
+  assert.equal(q0.status, 200);
+  assert.deepEqual(q0.json, { status: 'answered', remaining: ['q1'] });
+
+  // A duplicate q0 is question-locked (409), NOT released: q1 stays open.
+  const duplicate = await api('/v1/decisions/conduit-push-batche2e1/respond', {
+    method: 'POST',
+    credential: deviceCredential,
+    body: { question_id: 'q0', answer: 'prod' },
+  });
+  assert.equal(duplicate.status, 409);
+  assert.equal(duplicate.json.error, 'already_answered');
+
+  // The bare path stays a working alias for the same handler: q1 completes.
+  const q1 = await api('/v1/decisions/conduit-push-batche2e1', {
+    method: 'POST',
+    credential: deviceCredential,
+    body: { question_id: 'q1', answer: '["unit"]' },
+  });
+  assert.equal(q1.status, 200);
+  assert.deepEqual(q1.json, { status: 'answered', remaining: [] });
+
+  const done = await api('/v1/decisions/conduit-push-batche2e1', { credential: gatewayCredential });
+  assert.equal(done.status, 200);
+  assert.equal(done.json.status, 'answered');
+  assert.deepEqual(done.json.remaining, []);
+  assert.deepEqual({ ...done.json.answers }, { q0: 'staging', q1: '["unit"]' });
+
+  // ── Release semantics: the native path won, the plugin deletes. ──
+  await api('/v1/events', {
+    method: 'POST',
+    credential: gatewayCredential,
+    body: {
+      type: 'input.needed',
+      event_id: 'input:batch0000002',
+      session_id: 'sess-batch',
+      profile: 'default',
+      decision: {
+        kind: 'clarify',
+        request_id: 'conduit-push-batche2e2',
+        question: 'Second?',
+        questions: [{ qid: 'q0', question: 'Second?', choices: ['a'], multi_select: false }],
+      },
+    },
+  });
+  const released = await api('/v1/decisions/conduit-push-batche2e2', { method: 'DELETE', credential: gatewayCredential });
+  assert.equal(released.status, 200);
+  // A late device answer reports decision_released (410), NOT qid-locked.
+  const late = await api('/v1/decisions/conduit-push-batche2e2/respond', {
+    method: 'POST',
+    credential: deviceCredential,
+    body: { question_id: 'q0', answer: 'a' },
+  });
+  assert.equal(late.status, 410);
+  assert.equal(late.json.error, 'decision_released');
+  // The poller sees the release and falls back to the original path.
+  const pollReleased = await api('/v1/decisions/conduit-push-batche2e2', { credential: gatewayCredential });
+  assert.deepEqual(pollReleased.json, { status: 'unknown' });
+
+  // ── An oversized batch is parked undeliverable: the size guard stripped
+  // the card from the APNs payload, so the plugin must stop polling. ──
+  const oversized = await api('/v1/events', {
+    method: 'POST',
+    credential: gatewayCredential,
+    body: {
+      type: 'input.needed',
+      event_id: 'input:batch0000003',
+      session_id: 'sess-batch',
+      profile: 'default',
+      decision: {
+        kind: 'clarify',
+        request_id: 'conduit-push-batche2e3',
+        question: 'Huge?',
+        questions: Array.from({ length: 8 }, (_, i) => ({
+          qid: `q${i}`,
+          question: 'x'.repeat(500),
+          choices: Array.from({ length: 8 }, (_, j) => 'y'.repeat(80)),
+          multi_select: false,
+        })),
+      },
+    },
+  });
+  assert.equal(oversized.status, 202);
+  assert.deepEqual(oversized.json, { accepted: true, delivered: false });
+  const oversizedPoll = await api('/v1/decisions/conduit-push-batche2e3', { credential: gatewayCredential });
+  assert.equal(oversizedPoll.json.status, 'pending');
+  assert.equal(oversizedPoll.json.deliverable, false, 'a size-guard-stripped card must be undeliverable');
+});
+
 test('clarify decision: push → device answer → gateway poll', async () => {
   // Device registers with notifications disabled so event delivery skips APNs.
   const registered = await api('/v1/installations', {

--- a/relay/test/decisions.e2e.test.mjs
+++ b/relay/test/decisions.e2e.test.mjs
@@ -4,6 +4,7 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 import { after, before, test } from 'node:test';
 
 // Full clarify answer loop against a real relay process: register a device,
@@ -37,7 +38,9 @@ async function api(path, { method = 'GET', body, credential } = {}) {
 
 before(async () => {
   child = spawn(process.execPath, ['src/server.mjs'], {
-    cwd: new URL('.', import.meta.url).pathname.replace(/\/test\/$/, '/'),
+    // fileURLToPath: URL.pathname yields "/C:/…" on Windows, which spawn
+    // rejects; the file-path form works on every platform.
+    cwd: fileURLToPath(new URL('..', import.meta.url)),
     env: {
       ...process.env,
       HOST: '127.0.0.1',
@@ -223,7 +226,7 @@ test('clarify decision: push → device answer → gateway poll', async () => {
       // The plugin's event_id hashes the version (hex, no dots); keep the
       // fixture within the id charset the relay accepts.
       event_id: 'hello:020abcdef12',
-      plugin_version: '0.2.0',
+      plugin_version: '0.3.0',
       plugin_capabilities: ['approval-decisions', 'clarify-loop', 'version-reporting'],
     },
   });
@@ -233,11 +236,11 @@ test('clarify decision: push → device answer → gateway poll', async () => {
   // The device reads relay + plugin compatibility state.
   const meta = await api('/v1/meta', { credential: deviceCredential });
   assert.equal(meta.status, 200);
-  assert.equal(meta.json.version, '0.2.0');
+  assert.equal(meta.json.version, '0.3.0');
   assert.ok(meta.json.capabilities.includes('decisions'));
   const gatewayMeta = meta.json.gateways.find((gateway) => gateway.name === 'test gateway');
   assert.ok(gatewayMeta, 'paired gateway appears in meta');
-  assert.equal(gatewayMeta.plugin_version, '0.2.0');
+  assert.equal(gatewayMeta.plugin_version, '0.3.0');
   assert.ok(gatewayMeta.plugin_capabilities.includes('clarify-loop'));
   assert.ok(gatewayMeta.last_event_at);
 
@@ -274,14 +277,14 @@ test('clarify decision: push → device answer → gateway poll', async () => {
     body: {
       type: 'plugin.hello',
       event_id: 'hello:020abcdef12',
-      plugin_version: '0.2.0',
+      plugin_version: '0.3.0',
       plugin_capabilities: ['approval-decisions', 'clarify-loop', 'version-reporting'],
     },
   });
   const metaTwo = await api('/v1/meta', { credential: deviceCredential });
   const second = metaTwo.json.gateways.find((gateway) => gateway.name === 'second gateway');
   assert.ok(second, 'second gateway listed');
-  assert.equal(second.plugin_version, '0.2.0', 'duplicate hello id must still record the new gateway');
+  assert.equal(second.plugin_version, '0.3.0', 'duplicate hello id must still record the new gateway');
 
   // A pre-0.2 notifier sends events with no plugin_version: last_event_at is
   // stamped anyway so /v1/meta can flag "outdated plugin" instead of

--- a/relay/test/decisions.e2e.test.mjs
+++ b/relay/test/decisions.e2e.test.mjs
@@ -7,25 +7,32 @@ import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { after, before, test } from 'node:test';
 
-// Full clarify answer loop against a real relay process: register a device,
-// pair a gateway, push a clarify decision event (preferences disabled so no
-// APNs call is attempted — the pending decision is still stored), answer from
-// the device, and poll from the gateway. Nothing is mocked.
+// Full clarify answer loop against real relay processes: register a device,
+// pair a gateway, push clarify decision events, answer from the device, and
+// poll from the gateway. Two relays are spawned so APNs outcomes are
+// deterministic: the accept relay "delivers" every notification (APNS_MODE
+// stub, no network) and the reject relay fails every send — covering
+// delivery success, plain-banner fallback, and APNs-failure cleanup. Nothing
+// about the HTTP API is mocked.
 
 const dir = mkdtempSync(join(tmpdir(), 'conduit-relay-e2e-'));
 const port = 19000 + Math.floor(Math.random() * 1000);
+const rejectPort = port + 500;
 const baseUrl = `http://127.0.0.1:${port}`;
+const rejectBaseUrl = `http://127.0.0.1:${rejectPort}`;
 const dataPath = join(dir, 'relay-data.json');
+const rejectDataPath = join(dir, 'relay-data-reject.json');
 // The ApnsClient constructor parses the key eagerly, so the relay needs a
-// valid ES256 key to boot — an ephemeral one is fine; this test never sends.
+// valid ES256 key to boot — an ephemeral one is fine; sends are stubbed by
+// APNS_MODE so nothing ever reaches Apple.
 const keyPath = join(dir, 'ephemeral-key.pem');
 const { privateKey } = generateKeyPairSync('ec', { namedCurve: 'P-256' });
 writeFileSync(keyPath, privateKey.export({ type: 'sec1', format: 'pem' }));
 
-let child;
+const children = [];
 
-async function api(path, { method = 'GET', body, credential } = {}) {
-  const response = await fetch(`${baseUrl}${path}`, {
+async function api(base, path, { method = 'GET', body, credential } = {}) {
+  const response = await fetch(`${base}${path}`, {
     method,
     headers: {
       ...(body !== undefined ? { 'content-type': 'application/json' } : {}),
@@ -36,37 +43,45 @@ async function api(path, { method = 'GET', body, credential } = {}) {
   return { status: response.status, json: await response.json().catch(() => null) };
 }
 
-before(async () => {
-  child = spawn(process.execPath, ['src/server.mjs'], {
+async function startRelay(aPort, apnsMode, dataFile) {
+  const child = spawn(process.execPath, ['src/server.mjs'], {
     // fileURLToPath: URL.pathname yields "/C:/…" on Windows, which spawn
     // rejects; the file-path form works on every platform.
     cwd: fileURLToPath(new URL('..', import.meta.url)),
     env: {
       ...process.env,
       HOST: '127.0.0.1',
-      PORT: String(port),
-      PUBLIC_URL: `https://relay-${port}.example`,
-      DATA_PATH: dataPath,
+      PORT: String(aPort),
+      PUBLIC_URL: `https://relay-${aPort}.example`,
+      DATA_PATH: dataFile,
       APNS_KEY_PATH: keyPath,
       APNS_KEY_ID: 'AAAAAAAAAA',
       APNS_TEAM_ID: 'BBBBBBBBBB',
       APNS_TOPIC: 'com.milim.relay',
+      APNS_MODE: apnsMode,
     },
     stdio: 'ignore',
   });
+  const base = `http://127.0.0.1:${aPort}`;
   const deadline = Date.now() + 10_000;
   for (;;) {
     try {
-      const probe = await fetch(`${baseUrl}/healthz`);
+      const probe = await fetch(`${base}/healthz`);
       if (probe.ok) break;
     } catch {}
     if (Date.now() > deadline) throw new Error('relay did not start');
     await new Promise((resolve) => setTimeout(resolve, 100));
   }
+  return child;
+}
+
+before(async () => {
+  children.push(await startRelay(port, 'accept', dataPath));
+  children.push(await startRelay(rejectPort, 'reject', rejectDataPath));
 });
 
 after(() => {
-  child?.kill('SIGTERM');
+  for (const child of children) child?.kill('SIGTERM');
   rmSync(dir, { recursive: true, force: true });
 });
 
@@ -75,7 +90,7 @@ test('batch clarify end to end: questions[] survive intake, per-qid answers, rel
   // deliverability is computed from what actually survived into it. The
   // ephemeral key cannot pass Apple, so the send itself may 502 — the
   // decision is parked (with accurate deliverability) before that point.
-  const registered = await api('/v1/installations', {
+  const registered = await api(baseUrl, '/v1/installations', {
     method: 'POST',
     body: {
       bundle_id: 'com.milim.relay',
@@ -87,15 +102,15 @@ test('batch clarify end to end: questions[] survive intake, per-qid answers, rel
   assert.equal(registered.status, 201);
   const deviceCredential = registered.json.credential;
   const installationId = registered.json.installation.id;
-  const pairing = await api(`/v1/installations/${installationId}/pairings`, { method: 'POST', credential: deviceCredential });
-  const claimed = await api('/v1/pairings/claim', {
+  const pairing = await api(baseUrl, `/v1/installations/${installationId}/pairings`, { method: 'POST', credential: deviceCredential });
+  const claimed = await api(baseUrl, '/v1/pairings/claim', {
     method: 'POST',
     body: { pairing_code: pairing.json.pairing_code, gateway_name: 'batch gateway' },
   });
   const gatewayCredential = claimed.json.credential;
 
   // Push a two-question batch through the real event endpoint.
-  const event = await api('/v1/events', {
+  const event = await api(baseUrl, '/v1/events', {
     method: 'POST',
     credential: gatewayCredential,
     body: {
@@ -115,19 +130,20 @@ test('batch clarify end to end: questions[] survive intake, per-qid answers, rel
       },
     },
   });
-  // A decision card that survives the size guard attempts APNs; in tests the
-  // ephemeral key is rejected (502). The decision is parked either way.
-  assert.ok([202, 502].includes(event.status), `event status ${event.status}`);
+  // A decision card that survives the size guard is delivered for real
+  // (accept-mode APNs): deliverable stays true and the plugin keeps polling.
+  assert.equal(event.status, 202);
+  assert.deepEqual(event.json, { accepted: true, delivered: true });
 
   // The stored decision kept the FULL batch, deliverable, and the open qids.
-  const poll = await api('/v1/decisions/conduit-push-batche2e1', { credential: gatewayCredential });
+  const poll = await api(baseUrl, '/v1/decisions/conduit-push-batche2e1', { credential: gatewayCredential });
   assert.equal(poll.status, 200);
   assert.equal(poll.json.status, 'pending');
   assert.equal(poll.json.deliverable, true, 'the card survived into the APNs payload');
   assert.deepEqual(poll.json.remaining, ['q0', 'q1']);
 
   // Device answers q0 through the iOS /respond route.
-  const q0 = await api('/v1/decisions/conduit-push-batche2e1/respond', {
+  const q0 = await api(baseUrl, '/v1/decisions/conduit-push-batche2e1/respond', {
     method: 'POST',
     credential: deviceCredential,
     body: { question_id: 'q0', answer: 'staging' },
@@ -136,7 +152,7 @@ test('batch clarify end to end: questions[] survive intake, per-qid answers, rel
   assert.deepEqual(q0.json, { status: 'answered', remaining: ['q1'] });
 
   // A duplicate q0 is question-locked (409), NOT released: q1 stays open.
-  const duplicate = await api('/v1/decisions/conduit-push-batche2e1/respond', {
+  const duplicate = await api(baseUrl, '/v1/decisions/conduit-push-batche2e1/respond', {
     method: 'POST',
     credential: deviceCredential,
     body: { question_id: 'q0', answer: 'prod' },
@@ -145,7 +161,7 @@ test('batch clarify end to end: questions[] survive intake, per-qid answers, rel
   assert.equal(duplicate.json.error, 'already_answered');
 
   // The bare path stays a working alias for the same handler: q1 completes.
-  const q1 = await api('/v1/decisions/conduit-push-batche2e1', {
+  const q1 = await api(baseUrl, '/v1/decisions/conduit-push-batche2e1', {
     method: 'POST',
     credential: deviceCredential,
     body: { question_id: 'q1', answer: '["unit"]' },
@@ -153,14 +169,14 @@ test('batch clarify end to end: questions[] survive intake, per-qid answers, rel
   assert.equal(q1.status, 200);
   assert.deepEqual(q1.json, { status: 'answered', remaining: [] });
 
-  const done = await api('/v1/decisions/conduit-push-batche2e1', { credential: gatewayCredential });
+  const done = await api(baseUrl, '/v1/decisions/conduit-push-batche2e1', { credential: gatewayCredential });
   assert.equal(done.status, 200);
   assert.equal(done.json.status, 'answered');
   assert.deepEqual(done.json.remaining, []);
   assert.deepEqual({ ...done.json.answers }, { q0: 'staging', q1: '["unit"]' });
 
   // ── Release semantics: the native path won, the plugin deletes. ──
-  await api('/v1/events', {
+  await api(baseUrl, '/v1/events', {
     method: 'POST',
     credential: gatewayCredential,
     body: {
@@ -176,10 +192,10 @@ test('batch clarify end to end: questions[] survive intake, per-qid answers, rel
       },
     },
   });
-  const released = await api('/v1/decisions/conduit-push-batche2e2', { method: 'DELETE', credential: gatewayCredential });
+  const released = await api(baseUrl, '/v1/decisions/conduit-push-batche2e2', { method: 'DELETE', credential: gatewayCredential });
   assert.equal(released.status, 200);
   // A late device answer reports decision_released (410), NOT qid-locked.
-  const late = await api('/v1/decisions/conduit-push-batche2e2/respond', {
+  const late = await api(baseUrl, '/v1/decisions/conduit-push-batche2e2/respond', {
     method: 'POST',
     credential: deviceCredential,
     body: { question_id: 'q0', answer: 'a' },
@@ -187,12 +203,12 @@ test('batch clarify end to end: questions[] survive intake, per-qid answers, rel
   assert.equal(late.status, 410);
   assert.equal(late.json.error, 'decision_released');
   // The poller sees the release and falls back to the original path.
-  const pollReleased = await api('/v1/decisions/conduit-push-batche2e2', { credential: gatewayCredential });
+  const pollReleased = await api(baseUrl, '/v1/decisions/conduit-push-batche2e2', { credential: gatewayCredential });
   assert.deepEqual(pollReleased.json, { status: 'unknown' });
 
   // ── An oversized batch is parked undeliverable: the size guard stripped
   // the card from the APNs payload, so the plugin must stop polling. ──
-  const oversized = await api('/v1/events', {
+  const oversized = await api(baseUrl, '/v1/events', {
     method: 'POST',
     credential: gatewayCredential,
     body: {
@@ -214,15 +230,19 @@ test('batch clarify end to end: questions[] survive intake, per-qid answers, rel
     },
   });
   assert.equal(oversized.status, 202);
-  assert.deepEqual(oversized.json, { accepted: true, delivered: false });
-  const oversizedPoll = await api('/v1/decisions/conduit-push-batche2e3', { credential: gatewayCredential });
+  assert.deepEqual(
+    oversized.json,
+    { accepted: true, delivered: true },
+    'the plain input.needed fallback banner is still delivered when the size guard strips the card',
+  );
+  const oversizedPoll = await api(baseUrl, '/v1/decisions/conduit-push-batche2e3', { credential: gatewayCredential });
   assert.equal(oversizedPoll.json.status, 'pending');
   assert.equal(oversizedPoll.json.deliverable, false, 'a size-guard-stripped card must be undeliverable');
 });
 
 test('clarify decision: push → device answer → gateway poll', async () => {
   // Device registers with notifications disabled so event delivery skips APNs.
-  const registered = await api('/v1/installations', {
+  const registered = await api(baseUrl, '/v1/installations', {
     method: 'POST',
     body: {
       bundle_id: 'com.milim.relay',
@@ -236,12 +256,12 @@ test('clarify decision: push → device answer → gateway poll', async () => {
   const installationId = registered.json.installation.id;
 
   // Pair a gateway (device creates the code, gateway claims it).
-  const pairing = await api(`/v1/installations/${installationId}/pairings`, {
+  const pairing = await api(baseUrl, `/v1/installations/${installationId}/pairings`, {
     method: 'POST',
     credential: deviceCredential,
   });
   assert.equal(pairing.status, 201);
-  const claimed = await api('/v1/pairings/claim', {
+  const claimed = await api(baseUrl, '/v1/pairings/claim', {
     method: 'POST',
     body: { pairing_code: pairing.json.pairing_code, gateway_name: 'test gateway' },
   });
@@ -249,7 +269,7 @@ test('clarify decision: push → device answer → gateway poll', async () => {
   const gatewayCredential = claimed.json.credential;
 
   // Gateway pushes a clarify decision.
-  const event = await api('/v1/events', {
+  const event = await api(baseUrl, '/v1/events', {
     method: 'POST',
     credential: gatewayCredential,
     body: {
@@ -271,31 +291,31 @@ test('clarify decision: push → device answer → gateway poll', async () => {
   // Gateway polls: pending. This installation registered with enabled:false,
   // so no card was delivered and the decision reports deliverable:false —
   // the plugin's poll loop stops instead of waiting out the full budget.
-  const poll = await api('/v1/decisions/conduit-push-abc123', { credential: gatewayCredential });
+  const poll = await api(baseUrl, '/v1/decisions/conduit-push-abc123', { credential: gatewayCredential });
   assert.equal(poll.status, 200);
   assert.deepEqual(poll.json, { status: 'pending', deliverable: false });
 
   // Another installation's gateway must not see it.
-  const stranger = await api('/v1/installations', {
+  const stranger = await api(baseUrl, '/v1/installations', {
     method: 'POST',
     body: { bundle_id: 'com.milim.relay', device_token: 'b'.repeat(64), environment: 'production' },
   });
-  const strangerClaim = await api(`/v1/installations/${stranger.json.installation.id}/pairings`, {
+  const strangerClaim = await api(baseUrl, `/v1/installations/${stranger.json.installation.id}/pairings`, {
     method: 'POST',
     credential: stranger.json.credential,
   });
-  const strangerGateway = await api('/v1/pairings/claim', {
+  const strangerGateway = await api(baseUrl, '/v1/pairings/claim', {
     method: 'POST',
     body: { pairing_code: strangerClaim.json.pairing_code, gateway_name: 'stranger' },
   });
-  const strangerPoll = await api('/v1/decisions/conduit-push-abc123', {
+  const strangerPoll = await api(baseUrl, '/v1/decisions/conduit-push-abc123', {
     credential: strangerGateway.json.credential,
   });
   assert.equal(strangerPoll.status, 200);
   assert.equal(strangerPoll.json.status, 'unknown');
 
   // The stranger device cannot answer either.
-  const strangerAnswer = await api('/v1/decisions/conduit-push-abc123', {
+  const strangerAnswer = await api(baseUrl, '/v1/decisions/conduit-push-abc123', {
     method: 'POST',
     credential: stranger.json.credential,
     body: { answer: 'Blue' },
@@ -303,7 +323,7 @@ test('clarify decision: push → device answer → gateway poll', async () => {
   assert.equal(strangerAnswer.status, 404);
 
   // The paired device answers; the gateway observes the answer.
-  const answer = await api('/v1/decisions/conduit-push-abc123', {
+  const answer = await api(baseUrl, '/v1/decisions/conduit-push-abc123', {
     method: 'POST',
     credential: deviceCredential,
     body: { answer: 'Red' },
@@ -311,12 +331,12 @@ test('clarify decision: push → device answer → gateway poll', async () => {
   assert.equal(answer.status, 200);
   assert.equal(answer.json.status, 'answered');
 
-  const answered = await api('/v1/decisions/conduit-push-abc123', { credential: gatewayCredential });
+  const answered = await api(baseUrl, '/v1/decisions/conduit-push-abc123', { credential: gatewayCredential });
   assert.equal(answered.status, 200);
   assert.deepEqual(answered.json, { status: 'answered', answer: 'Red' });
 
   // Second answer attempts are rejected.
-  const reanswer = await api('/v1/decisions/conduit-push-abc123', {
+  const reanswer = await api(baseUrl, '/v1/decisions/conduit-push-abc123', {
     method: 'POST',
     credential: deviceCredential,
     body: { answer: 'Blue' },
@@ -325,7 +345,7 @@ test('clarify decision: push → device answer → gateway poll', async () => {
 
   // A duplicate delivery of the same event (same event_id) must not wipe the
   // parked decision's answer: dedupe happens before the pending-decision save.
-  const duplicate = await api('/v1/events', {
+  const duplicate = await api(baseUrl, '/v1/events', {
     method: 'POST',
     credential: gatewayCredential,
     body: {
@@ -343,11 +363,11 @@ test('clarify decision: push → device answer → gateway poll', async () => {
   });
   assert.equal(duplicate.status, 200);
   assert.equal(duplicate.json.duplicate, true);
-  const afterDuplicate = await api('/v1/decisions/conduit-push-abc123', { credential: gatewayCredential });
+  const afterDuplicate = await api(baseUrl, '/v1/decisions/conduit-push-abc123', { credential: gatewayCredential });
   assert.deepEqual(afterDuplicate.json, { status: 'answered', answer: 'Red' });
 
   // Empty answers are rejected outright.
-  const empty = await api('/v1/decisions/conduit-push-abc123', {
+  const empty = await api(baseUrl, '/v1/decisions/conduit-push-abc123', {
     method: 'POST',
     credential: deviceCredential,
     body: { answer: '   ' },
@@ -355,7 +375,7 @@ test('clarify decision: push → device answer → gateway poll', async () => {
   assert.equal(empty.status, 400);
 
   // Unknown ids are 404 for devices.
-  const unknown = await api('/v1/decisions/conduit-push-nope', {
+  const unknown = await api(baseUrl, '/v1/decisions/conduit-push-nope', {
     method: 'POST',
     credential: deviceCredential,
     body: { answer: 'x' },
@@ -363,12 +383,12 @@ test('clarify decision: push → device answer → gateway poll', async () => {
   assert.equal(unknown.status, 404);
 
   // Credentials are enforced on both endpoints.
-  const unauth = await api('/v1/decisions/conduit-push-abc123');
+  const unauth = await api(baseUrl, '/v1/decisions/conduit-push-abc123');
   assert.equal(unauth.status, 401);
 
   // Plugin version announcement: a control event that never notifies but
   // records the gateway's plugin state for the compatibility view.
-  const hello = await api('/v1/events', {
+  const hello = await api(baseUrl, '/v1/events', {
     method: 'POST',
     credential: gatewayCredential,
     body: {
@@ -384,7 +404,7 @@ test('clarify decision: push → device answer → gateway poll', async () => {
   assert.deepEqual(hello.json, { accepted: true, delivered: false });
 
   // The device reads relay + plugin compatibility state.
-  const meta = await api('/v1/meta', { credential: deviceCredential });
+  const meta = await api(baseUrl, '/v1/meta', { credential: deviceCredential });
   assert.equal(meta.status, 200);
   assert.equal(meta.json.version, '0.3.0');
   assert.ok(meta.json.capabilities.includes('decisions'));
@@ -395,7 +415,7 @@ test('clarify decision: push → device answer → gateway poll', async () => {
   assert.ok(gatewayMeta.last_event_at);
 
   // A later real event refreshes the recorded plugin version.
-  await api('/v1/events', {
+  await api(baseUrl, '/v1/events', {
     method: 'POST',
     credential: gatewayCredential,
     body: {
@@ -406,22 +426,22 @@ test('clarify decision: push → device answer → gateway poll', async () => {
       plugin_capabilities: ['approval-decisions', 'clarify-loop'],
     },
   });
-  const metaAfter = await api('/v1/meta', { credential: deviceCredential });
+  const metaAfter = await api(baseUrl, '/v1/meta', { credential: deviceCredential });
   const refreshed = metaAfter.json.gateways.find((gateway) => gateway.name === 'test gateway');
   assert.equal(refreshed.plugin_version, '0.2.1');
 
   // A second gateway on the same installation running the same plugin version
   // sends the same deterministic hello id; it must still be recorded even
   // though the event itself dedupes.
-  const secondPairing = await api(`/v1/installations/${installationId}/pairings`, {
+  const secondPairing = await api(baseUrl, `/v1/installations/${installationId}/pairings`, {
     method: 'POST',
     credential: deviceCredential,
   });
-  const secondClaim = await api('/v1/pairings/claim', {
+  const secondClaim = await api(baseUrl, '/v1/pairings/claim', {
     method: 'POST',
     body: { pairing_code: secondPairing.json.pairing_code, gateway_name: 'second gateway' },
   });
-  await api('/v1/events', {
+  await api(baseUrl, '/v1/events', {
     method: 'POST',
     credential: secondClaim.json.credential,
     body: {
@@ -431,7 +451,7 @@ test('clarify decision: push → device answer → gateway poll', async () => {
       plugin_capabilities: ['approval-decisions', 'clarify-loop', 'version-reporting'],
     },
   });
-  const metaTwo = await api('/v1/meta', { credential: deviceCredential });
+  const metaTwo = await api(baseUrl, '/v1/meta', { credential: deviceCredential });
   const second = metaTwo.json.gateways.find((gateway) => gateway.name === 'second gateway');
   assert.ok(second, 'second gateway listed');
   assert.equal(second.plugin_version, '0.3.0', 'duplicate hello id must still record the new gateway');
@@ -439,7 +459,7 @@ test('clarify decision: push → device answer → gateway poll', async () => {
   // A pre-0.2 notifier sends events with no plugin_version: last_event_at is
   // stamped anyway so /v1/meta can flag "outdated plugin" instead of
   // "waiting for the first notification".
-  await api('/v1/events', {
+  await api(baseUrl, '/v1/events', {
     method: 'POST',
     credential: secondClaim.json.credential,
     body: {
@@ -448,16 +468,164 @@ test('clarify decision: push → device answer → gateway poll', async () => {
       session_id: 'sess-2',
     },
   });
-  const metaLegacy = await api('/v1/meta', { credential: deviceCredential });
+  const metaLegacy = await api(baseUrl, '/v1/meta', { credential: deviceCredential });
   const legacyGateway = metaLegacy.json.gateways.find((gateway) => gateway.name === 'second gateway');
   // (Second gateway reported 0.2.0 via hello earlier; strip it to simulate
   // the never-reported shape and assert the last_event_at contract.)
   assert.ok(legacyGateway.last_event_at, 'every accepted event stamps last_event_at');
 
   // Meta requires the device credential, and never leaks cross-installation.
-  const metaUnauth = await api('/v1/meta');
+  const metaUnauth = await api(baseUrl, '/v1/meta');
   assert.equal(metaUnauth.status, 401);
-  const strangerMeta = await api('/v1/meta', { credential: stranger.json.credential });
+  const strangerMeta = await api(baseUrl, '/v1/meta', { credential: stranger.json.credential });
   assert.equal(strangerMeta.status, 200);
   assert.ok(strangerMeta.json.gateways.every((gateway) => gateway.name !== 'test gateway'), 'cross-installation gateways never leak');
+});
+
+test('decision_cards=false still delivers the plain banner and parks the decision undeliverable', async () => {
+  const registered = await api(baseUrl, '/v1/installations', {
+    method: 'POST',
+    body: {
+      bundle_id: 'com.milim.relay',
+      device_token: 'd'.repeat(64),
+      environment: 'production',
+      preferences: { enabled: true, input_needed: true, decision_cards: false },
+    },
+  });
+  assert.equal(registered.status, 201);
+  const deviceCredential = registered.json.credential;
+  const installationId = registered.json.installation.id;
+  const pairing = await api(baseUrl, `/v1/installations/${installationId}/pairings`, { method: 'POST', credential: deviceCredential });
+  const claimed = await api(baseUrl, '/v1/pairings/claim', {
+    method: 'POST',
+    body: { pairing_code: pairing.json.pairing_code, gateway_name: 'no-cards gateway' },
+  });
+  const gatewayCredential = claimed.json.credential;
+
+  const event = await api(baseUrl, '/v1/events', {
+    method: 'POST',
+    credential: gatewayCredential,
+    body: {
+      type: 'input.needed',
+      event_id: 'input:nocards00001',
+      session_id: 'sess-nocards',
+      profile: 'default',
+      decision: {
+        kind: 'clarify',
+        request_id: 'conduit-push-nocards1',
+        question: 'Which environment?',
+        questions: [{ qid: 'q0', question: 'Which environment?', choices: ['staging'], multi_select: false }],
+      },
+    },
+  });
+  // The user disabled answerable cards, NOT notifications: the ordinary
+  // input.needed banner is still delivered.
+  assert.equal(event.status, 202);
+  assert.deepEqual(event.json, { accepted: true, delivered: true });
+
+  // The parked decision is undeliverable, so the plugin immediately falls
+  // back to the native clarify path instead of waiting out its budget.
+  const poll = await api(baseUrl, '/v1/decisions/conduit-push-nocards1', { credential: gatewayCredential });
+  assert.equal(poll.status, 200);
+  assert.equal(poll.json.status, 'pending');
+  assert.equal(poll.json.deliverable, false);
+  assert.deepEqual(poll.json.remaining, ['q0'], 'the qids survive even when the card does not');
+});
+
+test('APNs rejection after parking flips a deliverable decision to undeliverable', async () => {
+  // The reject-mode relay fails every send AFTER intake parked the decision
+  // as deliverable (the structured card survived the size guard).
+  const registered = await api(rejectBaseUrl, '/v1/installations', {
+    method: 'POST',
+    body: {
+      bundle_id: 'com.milim.relay',
+      device_token: 'e'.repeat(64),
+      environment: 'production',
+      preferences: { enabled: true, decision_cards: true },
+    },
+  });
+  assert.equal(registered.status, 201);
+  const deviceCredential = registered.json.credential;
+  const installationId = registered.json.installation.id;
+  const pairing = await api(rejectBaseUrl, `/v1/installations/${installationId}/pairings`, { method: 'POST', credential: deviceCredential });
+  const claimed = await api(rejectBaseUrl, '/v1/pairings/claim', {
+    method: 'POST',
+    body: { pairing_code: pairing.json.pairing_code, gateway_name: 'reject gateway' },
+  });
+  const gatewayCredential = claimed.json.credential;
+
+  const event = await api(rejectBaseUrl, '/v1/events', {
+    method: 'POST',
+    credential: gatewayCredential,
+    body: {
+      type: 'input.needed',
+      event_id: 'input:reject000001',
+      session_id: 'sess-reject',
+      profile: 'default',
+      decision: {
+        kind: 'clarify',
+        request_id: 'conduit-push-reject1',
+        question: 'Which environment?',
+        questions: [{ qid: 'q0', question: 'Which environment?', choices: ['staging'], multi_select: false }],
+      },
+    },
+  });
+  // APNs rejected the send: the relay reports the failure upstream…
+  assert.equal(event.status, 502);
+  assert.equal(event.json.error, 'apns_rejected');
+
+  // …but the parked decision is no longer deliverable — the plugin's next
+  // poll sees it and promptly falls back to the native clarify path instead
+  // of polling a decision no device ever received.
+  const poll = await api(rejectBaseUrl, '/v1/decisions/conduit-push-reject1', { credential: gatewayCredential });
+  assert.equal(poll.status, 200);
+  assert.equal(poll.json.status, 'pending');
+  assert.equal(poll.json.deliverable, false, 'APNs rejection must flip the parked deliverable flag');
+  assert.deepEqual(poll.json.remaining, ['q0']);
+});
+
+test('unknown qid on a live batch decision is a bad request, not a missing decision', async () => {
+  const registered = await api(baseUrl, '/v1/installations', {
+    method: 'POST',
+    body: {
+      bundle_id: 'com.milim.relay',
+      device_token: 'f'.repeat(64),
+      environment: 'production',
+      preferences: { enabled: false, decision_cards: true },
+    },
+  });
+  const deviceCredential = registered.json.credential;
+  const installationId = registered.json.installation.id;
+  const pairing = await api(baseUrl, `/v1/installations/${installationId}/pairings`, { method: 'POST', credential: deviceCredential });
+  const claimed = await api(baseUrl, '/v1/pairings/claim', {
+    method: 'POST',
+    body: { pairing_code: pairing.json.pairing_code, gateway_name: 'qid gateway' },
+  });
+  const gatewayCredential = claimed.json.credential;
+  await api(baseUrl, '/v1/events', {
+    method: 'POST',
+    credential: gatewayCredential,
+    body: {
+      type: 'input.needed',
+      event_id: 'input:qidinvalid01',
+      session_id: 'sess-qid',
+      profile: 'default',
+      decision: {
+        kind: 'clarify',
+        request_id: 'conduit-push-qidcheck',
+        question: 'One?',
+        questions: [{ qid: 'q0', question: 'One?', choices: ['a'], multi_select: false }],
+      },
+    },
+  });
+  const answer = await api(baseUrl, '/v1/decisions/conduit-push-qidcheck/respond', {
+    method: 'POST',
+    credential: deviceCredential,
+    body: { question_id: 'q9', answer: 'a' },
+  });
+  assert.equal(answer.status, 400);
+  assert.equal(answer.json.error, 'invalid_question_id');
+  // The established meanings are untouched: the live decision still polls.
+  const poll = await api(baseUrl, '/v1/decisions/conduit-push-qidcheck', { credential: gatewayCredential });
+  assert.equal(poll.json.status, 'pending');
 });

--- a/relay/test/decisions.e2e.test.mjs
+++ b/relay/test/decisions.e2e.test.mjs
@@ -1,6 +1,7 @@
 import { strict as assert } from 'node:assert';
 import { generateKeyPairSync } from 'node:crypto';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { createServer as createNetServer } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { spawn } from 'node:child_process';
@@ -9,22 +10,32 @@ import { after, before, test } from 'node:test';
 
 // Full clarify answer loop against real relay processes: register a device,
 // pair a gateway, push clarify decision events, answer from the device, and
-// poll from the gateway. Two relays are spawned so APNs outcomes are
+// poll from the gateway. Four relays are spawned so APNs outcomes are
 // deterministic: the accept relay "delivers" every notification (APNS_MODE
-// stub, no network) and the reject relay fails every send — covering
-// delivery success, plain-banner fallback, and APNs-failure cleanup. Nothing
-// about the HTTP API is mocked.
+// stub, no network), the reject relay fails every send with a returned
+// rejection, the throw relay makes every send RAISE, and the dead-origin
+// relay runs the REAL ApnsClient transport against a closed port — a real
+// ClientHttp2Session 'error', which the APNS_MODE stubs (they bypass
+// ApnsClient entirely) cannot produce — to prove a connection-level failure
+// parks the decision undeliverable AND leaves the relay process alive.
+// Nothing about the HTTP API is mocked.
 
 const dir = mkdtempSync(join(tmpdir(), 'conduit-relay-e2e-'));
 const port = 19000 + Math.floor(Math.random() * 1000);
 const rejectPort = port + 500;
 const throwPort = port + 1000;
+const deadPort = port + 1500;
 const baseUrl = `http://127.0.0.1:${port}`;
 const rejectBaseUrl = `http://127.0.0.1:${rejectPort}`;
 const throwBaseUrl = `http://127.0.0.1:${throwPort}`;
+const deadBaseUrl = `http://127.0.0.1:${deadPort}`;
 const dataPath = join(dir, 'relay-data.json');
 const rejectDataPath = join(dir, 'relay-data-reject.json');
 const throwDataPath = join(dir, 'relay-data-throw.json');
+const deadDataPath = join(dir, 'relay-data-dead.json');
+// Where the dead-origin relay's REAL APNs transport points; resolved in
+// before() by reserving and releasing a loopback port.
+let deadOriginPort;
 // The ApnsClient constructor parses the key eagerly, so the relay needs a
 // valid ES256 key to boot — an ephemeral one is fine; sends are stubbed by
 // APNS_MODE so nothing ever reaches Apple.
@@ -46,7 +57,20 @@ async function api(base, path, { method = 'GET', body, credential } = {}) {
   return { status: response.status, json: await response.json().catch(() => null) };
 }
 
-async function startRelay(aPort, apnsMode, dataFile) {
+// Reserve a loopback port and release it: connecting there must be refused,
+// which surfaces as a genuine session-level 'error' inside ApnsClient.
+function closedPort() {
+  return new Promise((resolve, reject) => {
+    const probe = createNetServer();
+    probe.listen(0, '127.0.0.1', () => {
+      const port = probe.address().port;
+      probe.close(() => resolve(port));
+    });
+    probe.on('error', reject);
+  });
+}
+
+async function startRelay(aPort, apnsMode, dataFile, extraEnv = {}) {
   const child = spawn(process.execPath, ['src/server.mjs'], {
     // fileURLToPath: URL.pathname yields "/C:/…" on Windows, which spawn
     // rejects; the file-path form works on every platform.
@@ -62,6 +86,7 @@ async function startRelay(aPort, apnsMode, dataFile) {
       APNS_TEAM_ID: 'BBBBBBBBBB',
       APNS_TOPIC: 'com.milim.relay',
       APNS_MODE: apnsMode,
+      ...extraEnv,
     },
     stdio: 'ignore',
   });
@@ -79,9 +104,13 @@ async function startRelay(aPort, apnsMode, dataFile) {
 }
 
 before(async () => {
+  deadOriginPort = await closedPort();
   children.push(await startRelay(port, 'accept', dataPath));
   children.push(await startRelay(rejectPort, 'reject', rejectDataPath));
   children.push(await startRelay(throwPort, 'throw', throwDataPath));
+  children.push(await startRelay(deadPort, undefined, deadDataPath, {
+    APNS_ORIGIN: `https://127.0.0.1:${deadOriginPort}`,
+  }));
 });
 
 after(() => {
@@ -198,6 +227,7 @@ test('batch clarify end to end: questions[] survive intake, per-qid answers, rel
   });
   const released = await api(baseUrl, '/v1/decisions/conduit-push-batche2e2', { method: 'DELETE', credential: gatewayCredential });
   assert.equal(released.status, 200);
+  assert.deepEqual(released.json, { status: 'cancelled' }, 'a LIVE decision release reports cancelled');
   // A late device answer reports decision_released (410), NOT qid-locked.
   const late = await api(baseUrl, '/v1/decisions/conduit-push-batche2e2/respond', {
     method: 'POST',
@@ -338,6 +368,12 @@ test('clarify decision: push → device answer → gateway poll', async () => {
   const answered = await api(baseUrl, '/v1/decisions/conduit-push-abc123', { credential: gatewayCredential });
   assert.equal(answered.status, 200);
   assert.deepEqual(answered.json, { status: 'answered', answer: 'Red' });
+
+  // Releasing an ALREADY-COMPLETED decision is a diagnostic, not an error:
+  // same 200, distinct status string so gateway logs can tell the two apart.
+  const completed = await api(baseUrl, '/v1/decisions/conduit-push-abc123', { method: 'DELETE', credential: gatewayCredential });
+  assert.equal(completed.status, 200);
+  assert.deepEqual(completed.json, { status: 'already_completed' });
 
   // Second answer attempts are rejected.
   const reanswer = await api(baseUrl, '/v1/decisions/conduit-push-abc123', {
@@ -791,4 +827,66 @@ test('release succeeds even after the poll quota is exhausted', async () => {
   });
   assert.equal(late.status, 410);
   assert.equal(late.json.error, 'decision_released');
+});
+
+test('a REAL APNs session failure parks the decision undeliverable and the relay survives', async () => {
+  // The dead-origin relay runs the real ApnsClient transport (no APNS_MODE
+  // stub) pointed at a closed loopback port, so the HTTP/2 CONNECT fails at
+  // the session level — the failure shape the APNS_MODE=throw stub cannot
+  // produce. Notifications are ENABLED (default preferences) so intake
+  // actually calls the transport instead of skipping it.
+  const registered = await api(deadBaseUrl, '/v1/installations', {
+    method: 'POST',
+    body: {
+      bundle_id: 'com.milim.relay',
+      device_token: 'e'.repeat(64),
+      environment: 'production',
+    },
+  });
+  assert.equal(registered.status, 201);
+  const deviceCredential = registered.json.credential;
+  const installationId = registered.json.installation.id;
+  const pairing = await api(deadBaseUrl, `/v1/installations/${installationId}/pairings`, { method: 'POST', credential: deviceCredential });
+  const claimed = await api(deadBaseUrl, '/v1/pairings/claim', {
+    method: 'POST',
+    body: { pairing_code: pairing.json.pairing_code, gateway_name: 'dead-origin gateway' },
+  });
+  const gatewayCredential = claimed.json.credential;
+
+  const event = await api(deadBaseUrl, '/v1/events', {
+    method: 'POST',
+    credential: gatewayCredential,
+    body: {
+      type: 'input.needed',
+      event_id: 'input:deadapns0001',
+      session_id: 'sess-dead',
+      profile: 'default',
+      decision: {
+        kind: 'clarify',
+        request_id: 'conduit-push-dead1',
+        question: 'Which environment?',
+        choices: ['staging', 'prod'],
+      },
+    },
+  });
+  // The thrown transport failure is converted to the same outcome as a
+  // returned rejection: reported upstream, decision flipped undeliverable.
+  assert.equal(event.status, 502);
+  assert.equal(event.json.error, 'apns_unreachable');
+
+  // The decision WAS parked before the send, and the plugin's poller must
+  // see deliverable:false so it stops waiting and falls back to the native
+  // clarify path.
+  const poll = await api(deadBaseUrl, '/v1/decisions/conduit-push-dead1', { credential: gatewayCredential });
+  assert.equal(poll.status, 200);
+  assert.deepEqual(poll.json, { status: 'pending', deliverable: false });
+
+  // THE regression assertion: the session 'error' event must have been
+  // converted into the rejected send promise — an unhandled 'error' would
+  // have killed this process, and both of these requests would fail.
+  const health = await api(deadBaseUrl, '/healthz');
+  assert.equal(health.status, 200);
+  assert.deepEqual(health.json, { ok: true });
+  const alivePoll = await api(deadBaseUrl, '/v1/decisions/conduit-push-dead1', { credential: gatewayCredential });
+  assert.equal(alivePoll.status, 200);
 });

--- a/relay/test/decisions.test.mjs
+++ b/relay/test/decisions.test.mjs
@@ -121,7 +121,8 @@ test('an unknown qid and cross-installation answers never resolve a batch', () =
     question: 'One?',
     questions: [{ qid: 'q0', question: 'One?', choices: ['a'], multi_select: false }],
   });
-  assert.equal(relay.respondPendingDecision('inst-1', 'conduit-push-batch2', 'a', 'q9').outcome, 'unknown');
+  assert.equal(relay.respondPendingDecision('inst-1', 'conduit-push-batch2', 'a', 'q9').outcome, 'invalid_question',
+    'an unknown qid on a live decision is a malformed request, not a missing decision');
   assert.equal(relay.respondPendingDecision('inst-2', 'conduit-push-batch2', 'a', 'q0').outcome, 'unknown');
   assert.equal(relay.pendingDecisionStatus('inst-1', 'gw-1', 'conduit-push-batch2').status, 'pending');
 });

--- a/relay/test/decisions.test.mjs
+++ b/relay/test/decisions.test.mjs
@@ -19,7 +19,7 @@ test('a same-id write from another installation never clobbers a parked decision
   relay.savePendingDecision({ id: 'conduit-push-x', installationId: 'inst-2', gatewayId: 'gw-2', question: 'evil' });
   assert.equal(relay.pendingDecisionStatus('inst-1', 'gw-1', 'conduit-push-x').status, 'pending');
   // The original installation can still answer its own decision.
-  assert.equal(relay.respondPendingDecision('inst-1', 'conduit-push-x', 'Red'), 'answered');
+  assert.equal(relay.respondPendingDecision('inst-1', 'conduit-push-x', 'Red').outcome, 'answered');
 });
 
 test('pending decision lifecycle: save → pending → answered → already', () => {
@@ -61,15 +61,134 @@ test('pending decision lifecycle: save → pending → answered → already', ()
   assert.deepEqual(relay.pendingDecisionStatus('inst-1', 'gw-2', 'conduit-push-abc123'), { status: 'unknown' });
   assert.deepEqual(relay.pendingDecisionStatus('inst-1', 'gw-1', 'nope'), { status: 'unknown' });
 
-  assert.equal(relay.respondPendingDecision('inst-1', 'conduit-push-abc123', 'Red'), 'answered');
+  assert.equal(relay.respondPendingDecision('inst-1', 'conduit-push-abc123', 'Red').outcome, 'answered');
   assert.deepEqual(
     relay.pendingDecisionStatus('inst-1', 'gw-1', 'conduit-push-abc123'),
     { status: 'answered', answer: 'Red' },
   );
   // A device from another installation cannot answer or re-answer.
-  assert.equal(relay.respondPendingDecision('inst-2', 'conduit-push-abc123', 'Blue'), 'unknown');
-  assert.equal(relay.respondPendingDecision('inst-1', 'conduit-push-abc123', 'Blue'), 'already_answered');
+  assert.equal(relay.respondPendingDecision('inst-2', 'conduit-push-abc123', 'Blue').outcome, 'unknown');
+  assert.equal(relay.respondPendingDecision('inst-1', 'conduit-push-abc123', 'Blue').outcome, 'already_answered');
   assert.equal(relay.pendingDecisionStatus('inst-1', 'gw-1', 'conduit-push-abc123').answer, 'Red');
+});
+
+test('batch decisions accumulate per-question answers and complete on the last qid', () => {
+  const relay = store();
+  relay.savePendingDecision({
+    id: 'conduit-push-batch1',
+    installationId: 'inst-1',
+    gatewayId: 'gw-1',
+    question: 'Which environment?',
+    choices: ['staging', 'prod'],
+    questions: [
+      { qid: 'q0', question: 'Which environment?', choices: ['staging', 'prod'], multi_select: false },
+      { qid: 'q1', question: 'Which tests?', choices: ['unit', 'ui'], multi_select: true },
+    ],
+  });
+
+  // While open, the poll reports the authoritative open-qid list.
+  const pending = relay.pendingDecisionStatus('inst-1', 'gw-1', 'conduit-push-batch1');
+  assert.equal(pending.status, 'pending');
+  assert.deepEqual(pending.remaining, ['q0', 'q1']);
+
+  // First answer locks ONLY its qid; the sibling stays open.
+  const first = relay.respondPendingDecision('inst-1', 'conduit-push-batch1', 'staging', 'q0');
+  assert.equal(first.outcome, 'answered');
+  assert.deepEqual(first.remaining, ['q1']);
+  assert.equal(relay.pendingDecisionStatus('inst-1', 'gw-1', 'conduit-push-batch1').remaining.join(','), 'q1');
+
+  // A concurrent device locking the same qid loses (first-answer-wins per qid).
+  assert.equal(relay.respondPendingDecision('inst-1', 'conduit-push-batch1', 'prod', 'q0').outcome, 'already_answered');
+
+  // The final answer completes the batch with every locked answer.
+  const last = relay.respondPendingDecision('inst-1', 'conduit-push-batch1', '["unit"]', 'q1');
+  assert.equal(last.outcome, 'answered');
+  assert.deepEqual(last.remaining, []);
+  const done = relay.pendingDecisionStatus('inst-1', 'gw-1', 'conduit-push-batch1');
+  assert.equal(done.status, 'answered');
+  assert.deepEqual(done.answers, { q0: 'staging', q1: '["unit"]' });
+  assert.deepEqual(done.remaining, []);
+});
+
+test('an unknown qid and cross-installation answers never resolve a batch', () => {
+  const relay = store();
+  relay.savePendingDecision({
+    id: 'conduit-push-batch2',
+    installationId: 'inst-1',
+    gatewayId: 'gw-1',
+    question: 'One?',
+    questions: [{ qid: 'q0', question: 'One?', choices: ['a'], multi_select: false }],
+  });
+  assert.equal(relay.respondPendingDecision('inst-1', 'conduit-push-batch2', 'a', 'q9').outcome, 'unknown');
+  assert.equal(relay.respondPendingDecision('inst-2', 'conduit-push-batch2', 'a', 'q0').outcome, 'unknown');
+  assert.equal(relay.pendingDecisionStatus('inst-1', 'gw-1', 'conduit-push-batch2').status, 'pending');
+});
+
+test('a legacy whole-decision answer on a batch counts as the first question only', () => {
+  const relay = store();
+  relay.savePendingDecision({
+    id: 'conduit-push-batch3',
+    installationId: 'inst-1',
+    gatewayId: 'gw-1',
+    question: 'Which environment?',
+    questions: [
+      { qid: 'q0', question: 'Which environment?', choices: ['staging'], multi_select: false },
+      { qid: 'q1', question: 'Which tests?', choices: ['unit'], multi_select: false },
+    ],
+  });
+  const result = relay.respondPendingDecision('inst-1', 'conduit-push-batch3', 'staging');
+  assert.equal(result.outcome, 'answered');
+  assert.deepEqual(result.remaining, ['q1'], 'A pre-batch device answers the collapsed copy; the batch stays open');
+  assert.equal(relay.pendingDecisionStatus('inst-1', 'gw-1', 'conduit-push-batch3').status, 'pending');
+});
+
+test('releasing a decision rejects late device answers', () => {
+  const relay = store();
+  relay.savePendingDecision({
+    id: 'conduit-push-batch4',
+    installationId: 'inst-1',
+    gatewayId: 'gw-1',
+    question: 'One?',
+    questions: [{ qid: 'q0', question: 'One?', choices: ['a'], multi_select: false }],
+  });
+  assert.equal(relay.cancelPendingDecision('inst-1', 'gw-1', 'conduit-push-batch4'), 'cancelled');
+  // The poller sees unknown and falls back to the original clarify path.
+  assert.deepEqual(relay.pendingDecisionStatus('inst-1', 'gw-1', 'conduit-push-batch4'), { status: 'unknown' });
+  // A late device answer cannot claim acceptance.
+  assert.equal(relay.respondPendingDecision('inst-1', 'conduit-push-batch4', 'a', 'q0').outcome, 'already_answered');
+  // Cancelling an already-completed decision is reported, not an error.
+  relay.savePendingDecision({
+    id: 'conduit-push-batch5',
+    installationId: 'inst-1',
+    gatewayId: 'gw-1',
+    question: 'One?',
+    questions: [{ qid: 'q0', question: 'One?', choices: ['a'], multi_select: false }],
+  });
+  relay.respondPendingDecision('inst-1', 'conduit-push-batch5', 'a', 'q0');
+  assert.equal(relay.cancelPendingDecision('inst-1', 'gw-1', 'conduit-push-batch5'), 'answered');
+  assert.equal(relay.cancelPendingDecision('inst-1', 'gw-1', 'nope'), 'unknown');
+});
+
+test('batch question lists are sanitized and bounded at intake', () => {
+  const relay = store();
+  relay.savePendingDecision({
+    id: 'conduit-push-batch6',
+    installationId: 'inst-1',
+    gatewayId: 'gw-1',
+    question: 'summary',
+    questions: [
+      { qid: 'q0', question: 'Kept', choices: ['a'], multi_select: true },
+      { qid: '', question: 'No qid dropped' },
+      { question: 'No qid dropped either' },
+      'not-an-object',
+      { qid: 'q7', question: 'x'.repeat(600), choices: Array.from({ length: 20 }, (_, i) => `c${i}`) },
+    ],
+  });
+  const stored = relay.data.pendingDecisions['conduit-push-batch6'].questions;
+  assert.equal(stored.length, 2);
+  assert.equal(stored[0].multiSelect, true);
+  assert.equal(stored[1].question.length, 500);
+  assert.equal(stored[1].choices.length, 8);
 });
 
 test('pending decisions survive a reload and expire past the TTL', () => {

--- a/relay/test/decisions.test.mjs
+++ b/relay/test/decisions.test.mjs
@@ -106,7 +106,9 @@ test('batch decisions accumulate per-question answers and complete on the last q
   assert.deepEqual(last.remaining, []);
   const done = relay.pendingDecisionStatus('inst-1', 'gw-1', 'conduit-push-batch1');
   assert.equal(done.status, 'answered');
-  assert.deepEqual(done.answers, { q0: 'staging', q1: '["unit"]' });
+  // Spread: the store keeps answers on a null-prototype map (prototype-
+  // pollution safety), and strict deep-equal compares prototypes.
+  assert.deepEqual({ ...done.answers }, { q0: 'staging', q1: '["unit"]' });
   assert.deepEqual(done.remaining, []);
 });
 
@@ -154,8 +156,9 @@ test('releasing a decision rejects late device answers', () => {
   assert.equal(relay.cancelPendingDecision('inst-1', 'gw-1', 'conduit-push-batch4'), 'cancelled');
   // The poller sees unknown and falls back to the original clarify path.
   assert.deepEqual(relay.pendingDecisionStatus('inst-1', 'gw-1', 'conduit-push-batch4'), { status: 'unknown' });
-  // A late device answer cannot claim acceptance.
-  assert.equal(relay.respondPendingDecision('inst-1', 'conduit-push-batch4', 'a', 'q0').outcome, 'already_answered');
+  // A late device answer reports RELEASED, not merely qid-locked: Conduit
+  // tears the whole pushed card down instead of settling one question.
+  assert.equal(relay.respondPendingDecision('inst-1', 'conduit-push-batch4', 'a', 'q0').outcome, 'released');
   // Cancelling an already-completed decision is reported, not an error.
   relay.savePendingDecision({
     id: 'conduit-push-batch5',
@@ -186,7 +189,7 @@ test('batch question lists are sanitized and bounded at intake', () => {
   });
   const stored = relay.data.pendingDecisions['conduit-push-batch6'].questions;
   assert.equal(stored.length, 2);
-  assert.equal(stored[0].multiSelect, true);
+  assert.equal(stored[0].multi_select, true, 'wire shape keeps snake_case multi_select');
   assert.equal(stored[1].question.length, 500);
   assert.equal(stored[1].choices.length, 8);
 });

--- a/relay/test/server.test.mjs
+++ b/relay/test/server.test.mjs
@@ -19,7 +19,7 @@ const approvalDecision = {
   choices: ['once', 'deny'],
 };
 
-test('notificationFor embeds a valid decision in both conduit payload paths', () => {
+test('notificationFor embeds the decision in body.conduit only; top-level stays routing-only', () => {
   const event = {
     eventId: 'approval:12345678',
     type: 'approval.needed',
@@ -28,12 +28,20 @@ test('notificationFor embeds a valid decision in both conduit payload paths', ()
     decision: approvalDecision,
   };
   const { payload } = notificationFor(event, preferences);
-  assert.equal(payload.conduit.decision.kind, 'approval');
-  assert.equal(payload.conduit.decision.session_key, 'sess-1');
-  assert.equal(payload.conduit.decision.description, 'Run a dangerous shell command');
-  assert.deepEqual(payload.conduit.decision.choices, ['once', 'deny']);
-  // The expo-notifications `body` mirror must carry the same decision.
-  assert.deepEqual(payload.body.conduit, payload.conduit);
+  // body.conduit is the canonical rich payload the iOS notification path reads.
+  assert.equal(payload.body.conduit.decision.kind, 'approval');
+  assert.equal(payload.body.conduit.decision.session_key, 'sess-1');
+  assert.equal(payload.body.conduit.decision.description, 'Run a dangerous shell command');
+  assert.deepEqual(payload.body.conduit.decision.choices, ['once', 'deny']);
+  // The top-level conduit copy is a ROUTING STUB: duplicating the structured
+  // decision there once doubled its byte cost against the APNs size guard.
+  assert.equal(payload.conduit.decision, undefined);
+  assert.deepEqual(payload.conduit, {
+    type: 'approval.needed',
+    session_id: 'sess-1',
+    profile: 'default',
+    gateway: undefined,
+  });
 });
 
 test('notificationFor omits decision when the event has none', () => {
@@ -66,7 +74,7 @@ test('notificationFor gates decision on the dedicated decision_cards preference'
   // Decision cards are independent of show_previews: previews-off users who
   // left decision_cards on still get answerable cards...
   const previewsOff = notificationFor(event, { show_previews: false, completion_sound: false });
-  assert.ok(previewsOff.payload.conduit.decision, 'previews-off must not disable decision cards');
+  assert.ok(previewsOff.payload.body.conduit.decision, 'previews-off must not disable decision cards');
   assert.equal(previewsOff.payload.aps.alert.body.includes('Run a dangerous'), false, 'banner text stays generic');
   // ...and turning just decision_cards off keeps the payload content-free.
   const cardsOff = notificationFor(event, { show_previews: true, decision_cards: false, completion_sound: false });
@@ -74,7 +82,7 @@ test('notificationFor gates decision on the dedicated decision_cards preference'
   assert.equal(cardsOff.payload.body.conduit.decision, undefined);
   // Legacy installations whose stored preferences predate the key default on.
   const legacy = notificationFor(event, { show_previews: false, completion_sound: false });
-  assert.ok(legacy.payload.conduit.decision !== undefined);
+  assert.ok(legacy.payload.body.conduit.decision !== undefined);
 });
 
 test('notificationFor degrades to a routing stub when the payload would exceed the APNs cap', () => {
@@ -159,7 +167,7 @@ test('validateEvent passes a bounded decision through', () => {
   assert.deepEqual(event.decision.choices, ['once', 'deny'], 'unknown choice strings are filtered');
 });
 
-test('notificationFor embeds every batch question in both conduit payload paths', () => {
+test('notificationFor embeds every batch question in the rich body payload', () => {
   const event = {
     type: 'input.needed',
     sessionId: 'sess-1',
@@ -179,13 +187,12 @@ test('notificationFor embeds every batch question in both conduit payload paths'
   };
   const preferences = { enabled: true, show_previews: true, decision_cards: true };
   const { payload } = notificationFor(event, preferences);
-  // Both conduit copies (top-level and notification-center data) must carry
-  // the FULL batch — this is exactly what APNs delivers to the device.
-  for (const conduit of [payload.conduit, payload.body.conduit]) {
-    assert.equal(conduit.decision.questions.length, 2);
-    assert.deepEqual(conduit.decision.questions.map((question) => question.qid), ['q0', 'q1']);
-    assert.equal(conduit.decision.questions[1].multi_select, true);
-  }
+  // The rich body payload — exactly what APNs delivers to the device —
+  // carries the FULL batch; the top-level copy stays a routing stub.
+  assert.equal(payload.body.conduit.decision.questions.length, 2);
+  assert.deepEqual(payload.body.conduit.decision.questions.map((question) => question.qid), ['q0', 'q1']);
+  assert.equal(payload.body.conduit.decision.questions[1].multi_select, true);
+  assert.equal(payload.conduit.decision, undefined);
 });
 
 test('notificationFor strips an oversized batch decision so the card cannot exceed APNs limits', () => {
@@ -226,4 +233,44 @@ test('validateDecision preserves a sanitized batch and deduplicates identities',
   assert.deepEqual(decision.questions.map((question) => question.qid), ['q0', 'q1']);
   assert.deepEqual(decision.questions[0].choices, ['a', 'b'], 'duplicate choice values collapse');
   assert.equal(decision.questions[1].multi_select, false, 'non-boolean multi_select never coerces to true');
+});
+
+test('a representative multi-question batch fits the budget with a single structured copy', () => {
+  // 3 questions x ~200-char text x 4 choices: comfortably deliverable now
+  // that the decision is serialized once, and it carries every qid.
+  const event = {
+    eventId: 'input:midsize0001',
+    type: 'input.needed',
+    sessionId: 'sess-midsize',
+    profile: 'default',
+    decision: {
+      kind: 'clarify',
+      request_id: 'conduit-push-midsize',
+      question: 'Implementation plan?',
+      questions: [0, 1, 2].map((index) => ({
+        qid: `q${index}`,
+        question: `Describe step ${index} of the rollout, including which services are affected, the expected downtime, and how a rollback would be performed if the step fails validation.` + ' Detail '.repeat(index + 1),
+        choices: [
+          `Proceed with step ${index} during the maintenance window`,
+          `Delay step ${index} until the follow-up release ships`,
+          `Ask the platform team to review step ${index} first`,
+          `Skip step ${index} entirely for this iteration`,
+        ],
+        multi_select: index === 2,
+      })),
+    },
+  };
+  const preferences = { enabled: true, show_previews: true, decision_cards: true };
+  const { payload } = notificationFor(event, preferences);
+  const size = Buffer.byteLength(JSON.stringify(payload));
+  assert.equal(
+    payload.body.conduit.decision.questions.length,
+    3,
+    'the full batch must reach the device payload',
+  );
+  assert.equal(payload.conduit.decision, undefined, 'top-level stays a routing stub');
+  assert.ok(
+    size <= 3800,
+    `a representative 3-question batch must fit the guard: ${size} bytes`,
+  );
 });

--- a/relay/test/server.test.mjs
+++ b/relay/test/server.test.mjs
@@ -158,3 +158,72 @@ test('validateEvent passes a bounded decision through', () => {
   assert.equal(event.decision.description.length, 500);
   assert.deepEqual(event.decision.choices, ['once', 'deny'], 'unknown choice strings are filtered');
 });
+
+test('notificationFor embeds every batch question in both conduit payload paths', () => {
+  const event = {
+    type: 'input.needed',
+    sessionId: 'sess-1',
+    profile: 'default',
+    title: 'Input needed',
+    body: 'Which environment?',
+    decision: {
+      kind: 'clarify',
+      request_id: 'conduit-push-batch-e2e',
+      question: 'Which environment?',
+      choices: ['staging', 'prod'],
+      questions: [
+        { qid: 'q0', question: 'Which environment?', choices: ['staging', 'prod'], multi_select: false },
+        { qid: 'q1', question: 'Which tests?', choices: ['unit', 'ui'], multi_select: true },
+      ],
+    },
+  };
+  const preferences = { enabled: true, show_previews: true, decision_cards: true };
+  const { payload } = notificationFor(event, preferences);
+  // Both conduit copies (top-level and notification-center data) must carry
+  // the FULL batch — this is exactly what APNs delivers to the device.
+  for (const conduit of [payload.conduit, payload.body.conduit]) {
+    assert.equal(conduit.decision.questions.length, 2);
+    assert.deepEqual(conduit.decision.questions.map((question) => question.qid), ['q0', 'q1']);
+    assert.equal(conduit.decision.questions[1].multi_select, true);
+  }
+});
+
+test('notificationFor strips an oversized batch decision so the card cannot exceed APNs limits', () => {
+  const event = {
+    type: 'input.needed',
+    sessionId: 'sess-1',
+    profile: 'default',
+    decision: {
+      kind: 'clarify',
+      request_id: 'conduit-push-huge',
+      question: 'Huge?',
+      questions: Array.from({ length: 8 }, (_, i) => ({
+        qid: `q${i}`,
+        question: 'x'.repeat(500),
+        choices: Array.from({ length: 8 }, (_, j) => 'y'.repeat(80)),
+        multi_select: false,
+      })),
+    },
+  };
+  const preferences = { enabled: true, show_previews: true, decision_cards: true };
+  const { payload } = notificationFor(event, preferences);
+  assert.equal(payload.conduit.decision, undefined, 'the size guard must strip the decision');
+  assert.equal(Buffer.byteLength(JSON.stringify(payload)) <= 4096, true);
+});
+
+test('validateDecision preserves a sanitized batch and deduplicates identities', () => {
+  const decision = validateDecision({
+    kind: 'clarify',
+    request_id: 'conduit-push-dedupe',
+    question: 'summary',
+    questions: [
+      { qid: 'q0', question: 'First', choices: ['a', 'a', 'b'], multi_select: false },
+      { qid: 'q0', question: 'Duplicate qid dropped' },
+      { qid: '__proto__', question: 'Prototype qid dropped' },
+      { qid: 'q1', question: 'Second', choices: [], multi_select: 'yes' },
+    ],
+  }, 'input.needed');
+  assert.deepEqual(decision.questions.map((question) => question.qid), ['q0', 'q1']);
+  assert.deepEqual(decision.questions[0].choices, ['a', 'b'], 'duplicate choice values collapse');
+  assert.equal(decision.questions[1].multi_select, false, 'non-boolean multi_select never coerces to true');
+});

--- a/tests/test_clarify_loop.py
+++ b/tests/test_clarify_loop.py
@@ -543,3 +543,9 @@ def test_single_question_decision_never_cancels_when_relay_wins():
         release.set()
     assert json.loads(result)["user_response"] == "Red"
     assert fake.cancelled_ids == []
+
+def test_user_agent_derives_from_the_plugin_version():
+    # One source of truth: bumping PLUGIN_VERSION updates the relay UA
+    # automatically instead of leaving a stale hand-written constant.
+    assert loop.client.USER_AGENT == f"Hermes-Conduit-Notifier/{loop.client.PLUGIN_VERSION}"
+    assert loop.client.PLUGIN_VERSION == "0.3.0"

--- a/tests/test_clarify_loop.py
+++ b/tests/test_clarify_loop.py
@@ -543,6 +543,32 @@ def test_batch_legacy_collapsed_answer_formats_absences():
     assert parsed["responses"][1]["question"] == "Which tests should run?"
 
 
+def test_batch_progress_resets_the_poll_backoff():
+    # A shrinking remaining set means answers are landing: the loop must
+    # return to the short interval instead of compounding the capped backoff
+    # while the user is mid-batch (each subsequent answer would otherwise
+    # wait out the growing, capped delay).
+    fake = _FakeState([
+        {"status": "pending", "remaining": ["q0", "q1"]},
+        {"status": "pending", "remaining": ["q1"], "answers": {"q0": "staging"}},
+        {"status": "answered", "answers": {"q1": "ui"}, "remaining": []},
+    ])
+    _install(fake)
+    sleeps = []
+    real_sleep = loop.time.sleep
+    loop.time.sleep = lambda seconds: sleeps.append(seconds)
+    original, release = _blocking_original("never used")
+    try:
+        result = loop.middleware(**_kwargs(original, _batch_args()))
+    finally:
+        loop.time.sleep = real_sleep
+        release.set()
+    assert json.loads(result)["responses"][1]["user_response"] == ["ui"]
+    # Poll 1 sleeps the base interval; poll 2 saw remaining shrink (2 -> 1),
+    # so its sleep RESETS to base instead of backing off to 2x base.
+    assert sleeps == [loop.POLL_INTERVAL_SECONDS, loop.POLL_INTERVAL_SECONDS]
+
+
 def test_unparseable_clarify_args_keep_the_original_path_without_a_card():
     fake = _FakeState([])
     _install(fake)

--- a/tests/test_clarify_loop.py
+++ b/tests/test_clarify_loop.py
@@ -50,13 +50,14 @@ import conduit_push.clarify_loop as loop  # noqa: E402
 
 
 class _FakeState:
-    """Stand-in for client.load_state / poll_decision / enqueue."""
+    """Stand-in for client.load_state / poll_decision / enqueue / cancel_decision."""
 
     def __init__(self, poll_results):
         self.paired = True
         self.poll_results = list(poll_results)
         self.enqueued = []
         self.poll_ids = []
+        self.cancelled_ids = []
 
     def load_state(self):
         return {"credential": "x"} if self.paired else None
@@ -73,16 +74,33 @@ class _FakeState:
     def enqueue(self, event):
         self.enqueued.append(event)
 
+    def cancel_decision(self, request_id):
+        # Stubbed so tests stay hermetic: the real client would attempt an
+        # HTTPS call the moment the original clarify path wins the race.
+        self.cancelled_ids.append(request_id)
+        return True
+
 
 def _install(fake):
     loop.client.load_state = fake.load_state
     loop.client.poll_decision = fake.poll_decision
     loop.client.enqueue = fake.enqueue
+    loop.client.cancel_decision = fake.cancel_decision
     loop.POLL_INTERVAL_SECONDS = 0.01
 
 
 def _kwargs(next_call, args, **extra):
     return {"tool_name": "clarify", "args": args, "next_call": next_call, "session_id": "sess-1", **extra}
+
+
+def _batch_args():
+    """A two-question clarify invocation in the current wire shape."""
+    return {
+        "questions": [
+            {"question": "Which environment?", "choices": ["staging", "prod"]},
+            {"question": "Which tests should run?", "choices": ["unit", "ui"], "multi_select": True},
+        ]
+    }
 
 
 def test_non_clarify_tools_pass_through_untouched():
@@ -366,3 +384,88 @@ def test_poll_delay_backs_off_and_caps():
         assert loop._poll_delay(500) == 10.0
     finally:
         loop.POLL_INTERVAL_SECONDS, loop.MAX_POLL_BACKOFF_SECONDS = old_base, old_cap
+
+
+def test_batch_push_preserves_every_question_and_relay_completion_wins():
+    fake = _FakeState([
+        {"status": "pending", "remaining": ["q0", "q1"], "answers": {}},
+        {"status": "answered", "answers": {"q0": "staging", "q1": '["unit"]'}, "remaining": []},
+    ])
+    _install(fake)
+    original, release = _blocking_original("never used")
+    try:
+        result = loop.middleware(**_kwargs(original, _batch_args()))
+    finally:
+        release.set()
+
+    # The pushed decision carried the FULL batch with gateway-style qids.
+    event = fake.enqueued[0]
+    decision = event["decision"]
+    assert decision["request_id"].startswith("conduit-push-")
+    assert [(q["qid"], q["question"]) for q in decision["questions"]] == [
+        ("q0", "Which environment?"),
+        ("q1", "Which tests should run?"),
+    ]
+    assert decision["questions"][1]["multi_select"] is True
+    assert event["body"] == "Which environment?", "the body stays the collapsed summary"
+    assert decision["question"] == "Which environment?"
+
+    # The relay completion formatted exactly like the built-in batch result.
+    parsed = json.loads(result)
+    assert parsed == {
+        "responses": [
+            {"question": "Which environment?", "choices_offered": ["staging", "prod"], "user_response": "staging"},
+            {"question": "Which tests should run?", "choices_offered": ["unit", "ui"], "user_response": ["unit"]},
+        ]
+    }
+    # The completed decision must not be cancelled after the relay won.
+    assert fake.cancelled_ids == []
+
+
+def test_native_answer_wins_and_releases_the_batch_decision():
+    fake = _FakeState([])
+    _install(fake)
+
+    def original(args):
+        return json.dumps({"responses": [{"question": "native", "user_response": "x"}]})
+
+    result = loop.middleware(**_kwargs(original, _batch_args()))
+    assert json.loads(result)["responses"][0]["question"] == "native"
+    assert len(fake.cancelled_ids) == 1, "the parked decision is released so late device answers are rejected"
+    assert fake.cancelled_ids[0].startswith("conduit-push-")
+
+
+def test_batch_legacy_collapsed_answer_formats_absences():
+    # An old relay/pre-batch device answers only the collapsed copy: the
+    # result keeps every row, with unanswered questions as empty responses
+    # (upstream absence semantics), never a fake full-batch success.
+    fake = _FakeState([{"status": "answered", "answer": "staging"}])
+    _install(fake)
+    original, release = _blocking_original()
+    try:
+        result = loop.middleware(**_kwargs(original, _batch_args()))
+    finally:
+        release.set()
+    parsed = json.loads(result)
+    assert [row["user_response"] for row in parsed["responses"]] == ["staging", ""]
+    assert parsed["responses"][1]["question"] == "Which tests should run?"
+
+
+def test_unparseable_clarify_args_keep_the_original_path_without_a_card():
+    fake = _FakeState([])
+    _install(fake)
+    result = loop.middleware(**_kwargs(lambda a: "original", {"questions": [{"no_question": True}]}))
+    assert result == "original"
+    assert fake.enqueued == []
+
+
+def test_single_question_decision_never_cancels_when_relay_wins():
+    fake = _FakeState([{"status": "answered", "answer": "Red"}])
+    _install(fake)
+    original, release = _blocking_original()
+    try:
+        result = loop.middleware(**_kwargs(original, {"question": "Which color?", "choices": ["Red", "Blue"]}))
+    finally:
+        release.set()
+    assert json.loads(result)["user_response"] == "Red"
+    assert fake.cancelled_ids == []

--- a/tests/test_clarify_loop.py
+++ b/tests/test_clarify_loop.py
@@ -386,6 +386,80 @@ def test_poll_delay_backs_off_and_caps():
         loop.POLL_INTERVAL_SECONDS, loop.MAX_POLL_BACKOFF_SECONDS = old_base, old_cap
 
 
+def test_one_question_questions_array_is_batch_protocol_and_formats_batch_result():
+    # A ONE-entry questions[] call is still batch protocol: the relay's
+    # answers map must format into the upstream batch result shape, never
+    # the legacy scalar shape.
+    fake = _FakeState([
+        {"status": "answered", "answers": {"q0": "staging"}, "remaining": []},
+    ])
+    _install(fake)
+    original, release = _blocking_original("never used")
+    try:
+        result = loop.middleware(**_kwargs(original, {
+            "questions": [{"question": "Which environment?", "choices": ["staging", "prod"]}],
+        }))
+    finally:
+        release.set()
+    parsed = json.loads(result)
+    assert parsed == {
+        "responses": [
+            {"question": "Which environment?", "choices_offered": ["staging", "prod"], "user_response": "staging"},
+        ]
+    }
+
+
+def test_legacy_scalar_single_question_still_formats_scalar_result():
+    fake = _FakeState([{"status": "answered", "answer": "staging"}])
+    _install(fake)
+    original, release = _blocking_original()
+    try:
+        result = loop.middleware(**_kwargs(original, {
+            "question": "Which environment?",
+            "choices": ["staging", "prod"],
+        }))
+    finally:
+        release.set()
+    parsed = json.loads(result)
+    assert parsed["user_response"] == "staging"
+    assert "responses" not in parsed, "the legacy scalar shape must not gain batch wrapping"
+
+
+def test_native_result_returns_without_waiting_for_a_slow_release():
+    # The release DELETE rides a daemon thread: a relay that hangs the
+    # cancellation must never delay the user's native answer.
+    fake = _FakeState([])
+    _install(fake)
+    cancel_started = threading.Event()
+    release_cancel = threading.Event()
+
+    def slow_cancel(request_id):
+        cancel_started.set()
+        release_cancel.wait(5)
+        fake.cancelled_ids.append(request_id)
+        return True
+
+    loop.client.cancel_decision = slow_cancel
+
+    def original(args):
+        return "native result"
+
+    started = threading.Event()
+    result_holder = {}
+
+    def run_middleware():
+        started.set()
+        result_holder["result"] = loop.middleware(**_kwargs(original, {"question": "Q?"}))
+
+    worker = threading.Thread(target=run_middleware, daemon=True)
+    worker.start()
+    worker.join(timeout=5)
+    assert not worker.is_alive(), "middleware returned while cancellation was still hanging"
+    assert result_holder["result"] == "native result"
+    assert cancel_started.wait(5), "the release must still be fired, just off-thread"
+    release_cancel.set()
+
+
 def test_batch_push_preserves_every_question_and_relay_completion_wins():
     fake = _FakeState([
         {"status": "pending", "remaining": ["q0", "q1"], "answers": {}},

--- a/tests/test_clarify_loop.py
+++ b/tests/test_clarify_loop.py
@@ -151,6 +151,9 @@ def test_relay_answer_wins_and_formats_like_the_builtin_tool():
     assert decision["request_id"].startswith("conduit-push-")
     assert decision["question"] == "Which color?"
     assert decision["choices"] == ["Red", "Blue"]
+    # A legacy scalar invocation pushes the SCALAR decision: no questions[],
+    # so the relay parks it on the scalar path and answers {"answer": ...}.
+    assert "questions" not in decision
     assert fake.poll_ids == [decision["request_id"]]
 
 
@@ -407,9 +410,20 @@ def test_one_question_questions_array_is_batch_protocol_and_formats_batch_result
             {"question": "Which environment?", "choices_offered": ["staging", "prod"], "user_response": "staging"},
         ]
     }
+    # Guard against "fixing" scalar by collapsing every single-question case:
+    # a one-entry questions[] invocation pushes the BATCH wire shape.
+    decision = fake.enqueued[0]["decision"]
+    assert [q["qid"] for q in decision["questions"]] == ["q0"]
+    assert decision["questions"][0]["question"] == "Which environment?"
 
 
 def test_legacy_scalar_single_question_still_formats_scalar_result():
+    # Provenance, not cardinality: this invocation used `question`, so the
+    # push must be the scalar decision (no questions[]) — even though the
+    # normalized internal batch has one entry. The relay then answers in the
+    # scalar shape ({status, answer}); a batch-parked decision would return
+    # {status, answers: {q0: ...}} and this branch would format an empty
+    # answer, which is exactly the regression the wire shape prevents.
     fake = _FakeState([{"status": "answered", "answer": "staging"}])
     _install(fake)
     original, release = _blocking_original()
@@ -420,6 +434,10 @@ def test_legacy_scalar_single_question_still_formats_scalar_result():
         }))
     finally:
         release.set()
+    decision = fake.enqueued[0]["decision"]
+    assert decision["question"] == "Which environment?"
+    assert decision["choices"] == ["staging", "prod"]
+    assert "questions" not in decision, "a scalar invocation must push a scalar decision"
     parsed = json.loads(result)
     assert parsed["user_response"] == "staging"
     assert "responses" not in parsed, "the legacy scalar shape must not gain batch wrapping"

--- a/tests/test_clarify_relay_e2e.py
+++ b/tests/test_clarify_relay_e2e.py
@@ -1,0 +1,348 @@
+"""End-to-end protocol provenance: the real plugin middleware vs a real relay.
+
+The unit tests mock the relay's poll responses, so they can drift from what
+plugin 0.3 + relay 0.3 actually put on the wire (that is exactly how the
+scalar push bug survived: the mock answered the OLD scalar shape while the
+plugin was really pushing a batch). These tests spawn the actual Node relay
+(``relay/src/server.mjs``, APNS_MODE=accept) and drive the full boundary:
+
+    legacy scalar args -> scalar decision -> scalar answer -> scalar result
+    questions[] args   -> batch decision  -> per-qid answers -> batch result
+
+The pushed event originates from ``clarify_loop.middleware`` itself (the same
+``push_event``/``clarify_decision``/``sanitize_decision`` chain production
+runs), is delivered by the real ``client.send_now``, and the gateway-side
+poll is the real ``client.poll_decision``.
+"""
+
+import importlib
+import importlib.util
+import json
+import os
+import pathlib
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import types
+import urllib.error
+import urllib.request
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+RELAY_DIR = ROOT / "relay"
+
+# Same hermetic Hermes stubs as test_clarify_loop.py (idempotent when that
+# module already ran in this process).
+if "hermes_constants" not in sys.modules:
+    _hermes_constants = types.ModuleType("hermes_constants")
+    _hermes_constants.get_hermes_home = lambda: pathlib.Path(tempfile.gettempdir())
+    sys.modules["hermes_constants"] = _hermes_constants
+if "tools" not in sys.modules:
+    _tools = types.ModuleType("tools")
+    _tools.__path__ = []
+    sys.modules["tools"] = _tools
+if "tools.clarify_tool" not in sys.modules:
+    _clarify_tool = types.ModuleType("tools.clarify_tool")
+
+    def _strip_recommended(text):
+        stripped = str(text).strip()
+        suffix = "(Recommended)"
+        if stripped.casefold().endswith(suffix.casefold()):
+            return stripped[: -len(suffix)].strip()
+        return stripped
+
+    _clarify_tool.strip_recommended = _strip_recommended
+    sys.modules["tools.clarify_tool"] = _clarify_tool
+
+# The repo directory name is hyphenated, so import the plugin modules under a
+# synthetic package (the same trick Hermes's plugin loader performs).
+if "conduit_push" not in sys.modules:
+    _pkg = types.ModuleType("conduit_push")
+    _pkg.__path__ = [str(ROOT)]
+    sys.modules["conduit_push"] = _pkg
+if "conduit_push.clarify_loop" not in sys.modules:
+    _spec = importlib.util.spec_from_file_location("conduit_push.clarify_loop", ROOT / "clarify_loop.py")
+    _module = importlib.util.module_from_spec(_spec)
+    sys.modules["conduit_push.clarify_loop"] = _module
+    _spec.loader.exec_module(_module)
+
+import conduit_push.clarify_loop as loop  # noqa: E402
+
+pytestmark = pytest.mark.skipif(shutil.which("node") is None, reason="node is required to run the real relay")
+
+
+def _free_port():
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _ephemeral_key_pem(node):
+    # The relay's ApnsClient parses the key eagerly; an ephemeral P-256 key
+    # satisfies it and is never used (APNS_MODE=accept never sends).
+    result = subprocess.run(
+        [node, "-e",
+         "const {generateKeyPairSync}=require('node:crypto');"
+         "const {privateKey}=generateKeyPairSync('ec',{namedCurve:'P-256'});"
+         "process.stdout.write(privateKey.export({type:'sec1',format:'pem'}));"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout
+
+
+def _wait_healthy(base, process):
+    deadline = time.time() + 15
+    while time.time() < deadline:
+        if process.poll() is not None:
+            raise RuntimeError("relay process exited during startup")
+        try:
+            with urllib.request.urlopen(f"{base}/healthz", timeout=1) as response:
+                if response.status == 200:
+                    return
+        except Exception:
+            time.sleep(0.1)
+    raise RuntimeError("relay did not become healthy")
+
+
+@pytest.fixture(scope="module")
+def relay():
+    node = shutil.which("node")
+    tmpdir = pathlib.Path(tempfile.mkdtemp(prefix="conduit-clarify-e2e-"))
+    port = _free_port()
+    base = f"http://127.0.0.1:{port}"
+    key_path = tmpdir / "ephemeral-key.pem"
+    key_path.write_text(_ephemeral_key_pem(node), encoding="utf-8")
+    env = {
+        **os.environ,
+        "HOST": "127.0.0.1",
+        "PORT": str(port),
+        "PUBLIC_URL": f"https://relay-{port}.example",
+        "DATA_PATH": str(tmpdir / "relay-data.json"),
+        "APNS_KEY_PATH": str(key_path),
+        "APNS_KEY_ID": "AAAAAAAAAA",
+        "APNS_TEAM_ID": "BBBBBBBBBB",
+        "APNS_TOPIC": "com.milim.relay",
+        # Every APNs send succeeds without touching the network, so parked
+        # decisions stay deliverable and the middleware's poll loop runs to
+        # the answer (a rejected/thrown send would flip it undeliverable and
+        # the middleware would fall back to the native path instead).
+        "APNS_MODE": "accept",
+    }
+    process = subprocess.Popen(
+        [node, "src/server.mjs"],
+        cwd=str(RELAY_DIR),
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        _wait_healthy(base, process)
+        yield {"base": base}
+    finally:
+        process.terminate()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+@pytest.fixture()
+def restore_real_client():
+    """Restore the real transport on the SHARED client module.
+
+    Must run per-test, not at import time: pytest imports every test module
+    during collection but runs them later, so test_clarify_loop's tests
+    install their hermetic fakes (load_state/poll_decision/enqueue) onto this
+    same module object AFTER this file was imported. Reloading here puts the
+    genuine functions back immediately before these tests run.
+    """
+    importlib.reload(loop.client)
+
+
+@pytest.fixture()
+def gateway(relay, restore_real_client, monkeypatch, tmp_path):
+    """One registered device + claimed gateway, with the plugin state the
+    real client functions read saved under a test-private path."""
+    base = relay["base"]
+    monkeypatch.setattr(loop.client, "state_path", lambda: tmp_path / "conduit-push.json")
+    registered = _request(base, "/v1/installations", method="POST", body={
+        "bundle_id": "com.milim.relay",
+        "device_token": "a" * 64,
+        "environment": "production",
+    })
+    assert registered[0] == 201, registered
+    device_credential = registered[1]["credential"]
+    installation_id = registered[1]["installation"]["id"]
+    pairing = _request(base, f"/v1/installations/{installation_id}/pairings", method="POST", credential=device_credential)
+    assert pairing[0] == 201, pairing
+    # The REAL pairing entry point — this saves the state that send_now and
+    # poll_decision later read.
+    state = loop.client.claim_pairing(pairing[1]["pairing_code"], relay_url=base, gateway_name="clarify e2e")
+    # PUBLIC_URL is a stand-in in tests; keep the saved state pointed at the
+    # local process so the plugin's requests reach the relay under test.
+    state["relay_url"] = base
+    loop.client.save_state(state)
+    return {"base": base, "device_credential": device_credential}
+
+
+@pytest.fixture()
+def fast_poll():
+    previous = loop.POLL_INTERVAL_SECONDS
+    loop.POLL_INTERVAL_SECONDS = 0.05
+    yield
+    loop.POLL_INTERVAL_SECONDS = previous
+
+
+def _request(base, path, *, method="GET", body=None, credential=""):
+    data = None if body is None else json.dumps(body).encode("utf-8")
+    headers = {}
+    if data is not None:
+        headers["Content-Type"] = "application/json"
+    if credential:
+        headers["Authorization"] = f"Bearer {credential}"
+    request = urllib.request.Request(f"{base}{path}", data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=10) as response:
+            return response.status, json.loads(response.read() or b"{}")
+    except urllib.error.HTTPError as error:
+        return error.code, json.loads(error.read() or b"{}")
+
+
+def _run_clarify(monkeypatch, args):
+    """Run loop.middleware against the real relay in a worker thread.
+
+    ``enqueue`` is intercepted only to make delivery synchronous and capture
+    the pushed event; the delivery itself is the real ``send_now``. The
+    original (native gateway) path blocks on ``release`` so the relay answer
+    wins the race, exactly like a desktop client that never answers.
+    """
+    events = []
+    real_send_now = loop.client.send_now
+
+    def capture_and_send(event):
+        events.append(event)
+        real_send_now(event)
+
+    monkeypatch.setattr(loop.client, "enqueue", capture_and_send)
+    release = threading.Event()
+    holder = {}
+
+    def blocking_original(unused_args):
+        release.wait(10)
+        return "native answer"
+
+    def run_middleware():
+        try:
+            holder["result"] = loop.middleware(
+                tool_name="clarify",
+                args=args,
+                next_call=blocking_original,
+                session_id="sess-e2e",
+            )
+        except Exception as exc:  # surfaced by the caller's assertions
+            holder["error"] = exc
+
+    worker = threading.Thread(target=run_middleware, daemon=True)
+    worker.start()
+    deadline = time.time() + 5
+    while not events and time.time() < deadline:
+        time.sleep(0.01)
+    return worker, holder, events, release
+
+
+def test_legacy_scalar_invocation_round_trips_scalar_through_the_real_relay(relay, gateway, fast_poll, monkeypatch):
+    worker, holder, events, release = _run_clarify(monkeypatch, {
+        "question": "Which environment?",
+        "choices": ["staging", "prod"],
+    })
+    try:
+        assert events, "the middleware never pushed the input.needed event"
+        event = events[0]
+        decision = event["decision"]
+        assert event["type"] == "input.needed"
+        assert decision["kind"] == "clarify"
+        assert decision["request_id"].startswith("conduit-push-")
+        assert decision["question"] == "Which environment?"
+        assert decision["choices"] == ["staging", "prod"]
+        # THE contract: a legacy scalar invocation pushes the scalar decision,
+        # so the relay parks it on the scalar path end to end.
+        assert "questions" not in decision, "legacy scalar must not push a batch decision"
+
+        # The device answers through the relay's scalar respond path.
+        status, payload = _request(
+            gateway["base"],
+            f"/v1/decisions/{decision['request_id']}/respond",
+            method="POST",
+            body={"answer": "staging"},
+            credential=gateway["device_credential"],
+        )
+        assert status == 200, payload
+        assert payload == {"status": "answered"}, payload
+
+        worker.join(timeout=10)
+        assert not worker.is_alive(), "middleware did not observe the relay answer"
+        assert "error" not in holder, holder.get("error")
+        assert json.loads(holder["result"]) == {
+            "question": "Which environment?",
+            "choices_offered": ["staging", "prod"],
+            "user_response": "staging",
+        }
+
+        # What the gateway's poll sees for a scalar decision is the scalar
+        # answer shape — the exact wire contract the mocked unit tests assume.
+        assert loop.client.poll_decision(decision["request_id"]) == {
+            "status": "answered",
+            "answer": "staging",
+        }
+    finally:
+        release.set()
+
+
+def test_one_entry_questions_invocation_round_trips_batch_through_the_real_relay(relay, gateway, fast_poll, monkeypatch):
+    # Guard against "fixing" scalar by collapsing every single-question case:
+    # a one-entry questions[] invocation is BATCH protocol on the wire too.
+    worker, holder, events, release = _run_clarify(monkeypatch, {
+        "questions": [{"question": "Which environment?", "choices": ["staging", "prod"]}],
+    })
+    try:
+        assert events, "the middleware never pushed the input.needed event"
+        decision = events[0]["decision"]
+        assert decision["request_id"].startswith("conduit-push-")
+        # Strict-boolean sanitizer contract: multi_select rides only when
+        # true; the relay's store adds the wire-shape false on intake.
+        assert decision["questions"] == [
+            {"qid": "q0", "question": "Which environment?", "choices": ["staging", "prod"]},
+        ]
+
+        status, payload = _request(
+            gateway["base"],
+            f"/v1/decisions/{decision['request_id']}/respond",
+            method="POST",
+            body={"answer": "staging", "question_id": "q0"},
+            credential=gateway["device_credential"],
+        )
+        assert status == 200, payload
+        assert payload == {"status": "answered", "remaining": []}, payload
+
+        worker.join(timeout=10)
+        assert not worker.is_alive(), "middleware did not observe the relay answer"
+        assert "error" not in holder, holder.get("error")
+        assert json.loads(holder["result"]) == {
+            "responses": [
+                {"question": "Which environment?", "choices_offered": ["staging", "prod"], "user_response": "staging"},
+            ]
+        }
+
+        # The gateway's poll sees the per-qid answers map, never a scalar answer.
+        poll = loop.client.poll_decision(decision["request_id"])
+        assert poll == {"status": "answered", "answers": {"q0": "staging"}, "remaining": []}, poll
+    finally:
+        release.set()

--- a/tests/test_clarify_relay_e2e.py
+++ b/tests/test_clarify_relay_e2e.py
@@ -148,23 +148,36 @@ def relay():
     finally:
         process.terminate()
         try:
-            process.wait(timeout=5)
+            # Generous for slow hosts: a still-exiting Node holding DATA_PATH
+            # open would race the tmpdir cleanup below.
+            process.wait(timeout=15)
         except subprocess.TimeoutExpired:
             process.kill()
+            process.wait(timeout=5)
         shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+_REAL_CLIENT_FUNCTIONS = ("load_state", "poll_decision", "enqueue", "cancel_decision", "send_now", "save_state", "state_path", "claim_pairing")
 
 
 @pytest.fixture()
 def restore_real_client():
-    """Restore the real transport on the SHARED client module.
+    """Pin the real transport onto the SHARED client module for this test.
 
     Must run per-test, not at import time: pytest imports every test module
-    during collection but runs them later, so test_clarify_loop's tests
-    install their hermetic fakes (load_state/poll_decision/enqueue) onto this
-    same module object AFTER this file was imported. Reloading here puts the
-    genuine functions back immediately before these tests run.
+    during collection but runs them later, so test_clarify_loop's tests may
+    have installed their hermetic fakes (load_state/poll_decision/enqueue/
+    cancel_decision) onto this same module object before these tests run.
+    Deliberately NOT importlib.reload: that would also wipe the fakes for
+    tests that run AFTER this file, and pytest makes no cross-file ordering
+    guarantee. Saving and restoring only this file's functions keeps both
+    orderings hermetic.
     """
+    saved = {name: getattr(loop.client, name) for name in _REAL_CLIENT_FUNCTIONS}
     importlib.reload(loop.client)
+    yield
+    for name, function in saved.items():
+        setattr(loop.client, name, function)
 
 
 @pytest.fixture()
@@ -228,8 +241,15 @@ def _run_clarify(monkeypatch, args):
     real_send_now = loop.client.send_now
 
     def capture_and_send(event):
-        events.append(event)
-        real_send_now(event)
+        # Deliver FIRST, signal second: the relay parks the pending decision
+        # before replying to /v1/events, so a returned send_now guarantees
+        # the decision is findable by the test's /respond request. Appending
+        # in finally keeps the event visible for diagnosis if the send raises
+        # (the holder error then fails the test loudly).
+        try:
+            real_send_now(event)
+        finally:
+            events.append(event)
 
     monkeypatch.setattr(loop.client, "enqueue", capture_and_send)
     release = threading.Event()
@@ -253,7 +273,7 @@ def _run_clarify(monkeypatch, args):
     worker = threading.Thread(target=run_middleware, daemon=True)
     worker.start()
     deadline = time.time() + 5
-    while not events and time.time() < deadline:
+    while not events and "error" not in holder and time.time() < deadline:
         time.sleep(0.01)
     return worker, holder, events, release
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -272,7 +272,7 @@ def test_sanitize_decision_bounds_batch_questions():
         "request_id": "conduit-push-x",
         "question": "summary",
         "questions": [
-            {"qid": "q0", "question": "x" * 900, "choices": ["y" * 200] * 20, "multi_select": True},
+            {"qid": "q0", "question": "x" * 900, "choices": [f"choice-{i}-" + "y" * 70 for i in range(20)], "multi_select": True},
             {"question": "no qid"},
             {"qid": "q1", "question": "kept", "multi_select": "truthy-coerced"},
         ],
@@ -281,8 +281,59 @@ def test_sanitize_decision_bounds_batch_questions():
     assert len(sanitized["questions"]) == 2
     first = sanitized["questions"][0]
     assert first["question"] == "x" * 500
-    assert first["choices"] == ["y" * 80] * 8
+    assert len(first["choices"]) == 8, "choice count is bounded like the relay"
+    assert len(set(first["choices"])) == 8
     assert first["multi_select"] is True
     assert sanitized["questions"][1]["qid"] == "q1"
     assert "multi_select" not in sanitized["questions"][1]
 
+
+def test_sanitize_decision_qid_contract_mirrors_the_relay():
+    # Same accepted charset, same reserved-name rejection, same
+    # first-qid-wins dedup as the relay's sanitizeBatchQuestions: a batch
+    # this plugin emits must never be silently shrunk by the relay.
+    sanitized = sanitize_decision({
+        "kind": "clarify",
+        "request_id": "conduit-push-sym",
+        "question": "summary",
+        "questions": [
+            {"qid": "q0", "question": "Kept", "choices": ["a", "a", "b"]},
+            {"qid": "q0", "question": "Duplicate qid dropped"},
+            {"qid": "__proto__", "question": "Reserved dropped"},
+            {"qid": "constructor", "question": "Reserved dropped too"},
+            {"qid": "bad charset!", "question": "Charset dropped"},
+            {"qid": "q1", "question": "Also kept", "choices": ["x", "x"]},
+        ],
+    })
+    assert [(question["qid"], question["question"]) for question in sanitized["questions"]] == [
+        ("q0", "Kept"),
+        ("q1", "Also kept"),
+    ]
+    assert sanitized["questions"][0]["choices"] == ["a", "b"], "duplicate choice values collapse"
+    assert sanitized["questions"][1]["choices"] == ["x"]
+
+
+def test_normalize_questions_locally_matches_upstream_raw_position_minting():
+    # The local mirror follows the upstream normalizer exactly: qids come
+    # from the RAW enumerate position and a malformed entry rejects the
+    # whole batch (upstream returns an error, it never skips).
+    batch = normalize_clarify_questions({
+        "questions": [
+            "Bare string question",
+            {"question": "Second", "choices": ["a"]},
+        ]
+    })
+    assert [entry["qid"] for entry in batch] == ["q0", "q1"]
+    assert batch[0]["question"] == "Bare string question"
+
+
+def test_normalize_questions_locally_rejects_whole_batch_on_malformed_entry():
+    # A leading malformed entry mirrors upstream's whole-batch error — the
+    # valid second question must NOT be renumbered onto the malformed slot.
+    batch = normalize_clarify_questions({
+        "questions": [
+            {"no_question": True},
+            {"question": "Valid second"},
+        ]
+    })
+    assert batch == [], "upstream rejects the batch; the mirror must not skip-and-renumber"

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from events import approval_decision, clarification_text, event_id, is_silent_response, push_event, sanitize_decision
+from events import approval_decision, clarify_decision, clarification_text, event_id, is_silent_response, normalize_clarify_questions, push_event, sanitize_decision
 
 
 def test_event_identifiers_are_stable_for_replayed_hooks():
@@ -206,3 +206,83 @@ def test_sanitize_decision_requires_choices_and_mirrors_relay_contract():
     # choices; mirror that here so plugin-side tests describe the real contract.
     assert sanitize_decision({"kind": "approval", "session_key": "s", "description": "d"}) == {}
     assert sanitize_decision({"kind": "approval", "session_key": "s", "description": "d", "choices": ["  "]}) == {}
+
+
+def test_normalize_clarify_questions_preserves_the_full_batch():
+    batch = normalize_clarify_questions({
+        "questions": [
+            {"question": "Which environment?", "choices": ["staging", "prod"]},
+            {"question": "Which tests?", "choices": [{"label": "unit"}, "ui"], "multi_select": True},
+            "Just one word?",
+        ]
+    })
+    assert [(entry["qid"], entry["question"]) for entry in batch] == [
+        ("q0", "Which environment?"),
+        ("q1", "Which tests?"),
+        ("q2", "Just one word?"),
+    ]
+    assert batch[0]["choices"] == ["staging", "prod"]
+    assert batch[1]["multi_select"] is True
+    assert batch[1]["choices"] == ["unit", "ui"], "dict-shaped choices flatten to labels"
+    assert batch[2]["multi_select"] is False
+
+
+def test_normalize_clarify_questions_scalar_becomes_one_question_batch():
+    batch = normalize_clarify_questions({
+        "question": "Deploy now?",
+        "choices": ["Ship it"],
+        "multi_select": True,
+    })
+    assert len(batch) == 1
+    assert batch[0] == {
+        "qid": "q0",
+        "id": None,
+        "question": "Deploy now?",
+        "choices": ["Ship it"],
+        "multi_select": True,
+    }
+    # multi_select without choices degrades like the gateway does.
+    assert normalize_clarify_questions({"question": "Notes?", "multi_select": True})[0]["multi_select"] is False
+
+
+def test_normalize_clarify_questions_unparseable_yields_no_question():
+    assert normalize_clarify_questions({}) == []
+    assert normalize_clarify_questions({"questions": [{"no_question": True}]}) == []
+    assert normalize_clarify_questions(None) == []
+
+
+def test_clarify_decision_carries_batch_and_collapsed_summary():
+    decision = clarify_decision(
+        request_id="conduit-push-x",
+        question="Which environment?",
+        choices=["staging", "prod"],
+        questions=[
+            {"qid": "q0", "question": "Which environment?", "choices": ["staging", "prod"], "multi_select": False},
+            {"qid": "q1", "question": "Notes?", "choices": [], "multi_select": False},
+        ],
+    )
+    assert decision["kind"] == "clarify"
+    assert decision["question"] == "Which environment?", "collapsed copy for pre-batch devices"
+    assert [q["qid"] for q in decision["questions"]] == ["q0", "q1"]
+
+
+def test_sanitize_decision_bounds_batch_questions():
+    sanitized = sanitize_decision({
+        "kind": "clarify",
+        "request_id": "conduit-push-x",
+        "question": "summary",
+        "questions": [
+            {"qid": "q0", "question": "x" * 900, "choices": ["y" * 200] * 20, "multi_select": True},
+            {"question": "no qid"},
+            {"qid": "q1", "question": "kept", "multi_select": "truthy-coerced"},
+        ],
+    })
+    assert sanitized["request_id"] == "conduit-push-x"
+    assert len(sanitized["questions"]) == 2
+    first = sanitized["questions"][0]
+    assert first["question"] == "x" * 500
+    assert first["choices"] == ["y" * 80] * 8
+    assert first["multi_select"] is True
+    assert sanitized["questions"][1]["qid"] == "q1"
+    assert "multi_select" not in sanitized["questions"][1]
+


### PR DESCRIPTION
Companion to kaishi00/hermes-conduit#127 (issue #123): the native iOS flow is fully batch-capable; this makes the background push/relay path match.

## Plugin
- `normalize_clarify_questions()` accepts the current `questions[]` protocol and the legacy scalar shape (normalized to a one-question batch). Upstream's own `_normalize_questions` is used when importable so qid minting matches the tool exactly; a local mirror covers older installs. Nothing is reduced to question 1 anymore.
- `clarify_decision` carries the full `questions[]` payload (qids, choices, multi_select) alongside the collapsed `question`/`choices` summary, so **pre-batch Conduit builds keep rendering an answerable first-question card**; `sanitize_decision` bounds and whitelists the batch (8 questions × 8 choices, same text caps, strict boolean multi_select, malformed entries dropped).
- Batch decisions complete only when EVERY qid is locked through the relay. The result is formatted exactly like the built-in tool's batch result (`{"responses": [...]}`, multi-select parsed back to lists via upstream parsing rules). A legacy collapsed answer formats as a batch with empty (absence) rows — never a fake full-batch success.
- When the original gateway path wins (Desktop/TUI answered natively) or the poll budget falls back to it, the plugin now RELEASES the parked decision, so a late device answer is rejected (409) instead of being reported as accepted while its result is discarded.

## Relay
- `savePendingDecision` stores a bounded, sanitized question list; answers accumulate **per qid with first-answer-wins per question**; polls report the authoritative `remaining` list; the decision is answered only when the last qid locks.
- `POST /v1/decisions/:id` accepts `question_id`-scoped answers and returns `remaining`; legacy bodies still work (on a batch they count as the collapsed first question only).
- `DELETE /v1/decisions/:id` (gateway-authenticated) releases a parked decision; released decisions report `unknown` to the poller (loop falls back to the original path) and 409 to devices.
- Fixed a pre-existing Windows bug in the e2e harness (`URL.pathname` as spawn cwd), so the relay suite runs everywhere.

## Compatibility matrix
- old plugin + new relay: unchanged (single-question decisions).
- new plugin + old relay: batch decision degrades to the collapsed card; the device's single answer is treated as question 1 and the original path's timeout bounds the rest.
- new plugin + new relay: full per-question batch answering, native-vs-relay first-completion-wins.

## Verification
- Plugin: 44/44 pytest (was 34) — batch normalization, decision payload, sanitizer bounds, relay-completion formatting, legacy collapse, release-on-native-win, and every pre-existing single-question behavior.
- Relay: 20/20 node --test including the real-process e2e loop (was 16) — per-qid lifecycle, duplicate-qid 409, unknown qid, legacy-on-batch, release semantics, intake sanitization.

## Known limitation (documented in README)
The relay cannot see native answers and the gateway cannot see relay answers, so a batch answered partly on Desktop and partly on Conduit stays open until the gateway's clarify timeout bounds it; first FULL completion wins and the losing path is discarded (never double-completed). Real-device APNs delivery still needs a TestFlight build to exercise end to end.