### PR TITLE
Post-merge hardening: queue-full clarify fallback, constant-time credential digests, batch-capacity docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,17 @@ the FULL batch to Conduit instead of collapsing it to the first question:
   ordinary input.needed banner is still delivered and the parked decision
   is marked `deliverable=false`, so the plugin immediately falls back to
   Hermes' native clarify path.
+- Bounds: the plugin and relay accept at most 8 questions × 8 choices per
+  batch (validation mirrored on both sides). That is the protocol/store
+  ceiling, NOT a guarantee that every valid batch fits an answerable card:
+  answerable-card capacity is bounded by Apple's ~4 KB APNs payload limit,
+  and therefore by the actual byte size of the question and choice text. A
+  valid batch whose serialized decision exceeds the payload budget is
+  never truncated or split — Hermes is still waiting on every qid, so a
+  partial card would collect answers for a batch that can never complete —
+  instead the WHOLE structured decision is dropped from the push (plain
+  input.needed banner, decision parked `deliverable=false`) and the plugin
+  falls back to Hermes' native clarify path.
 - The plugin returns the batch to Hermes exactly in the built-in tool's
   result shape (`{"responses": [...]}`, multi-select answers parsed back to
   lists). Protocol provenance comes from the original invocation: a

--- a/clarify_loop.py
+++ b/clarify_loop.py
@@ -119,7 +119,7 @@ def middleware(is_child_session: Callable[[str], bool] | None = None, **kwargs: 
         else None
     )
 
-    if not client.enqueue(push_event(
+    push = push_event(
         "input.needed",
         identifier=event_id("input", kwargs.get("turn_id"), kwargs.get("tool_call_id"), request_id),
         session_id=session_id,
@@ -131,7 +131,21 @@ def middleware(is_child_session: Callable[[str], bool] | None = None, **kwargs: 
             choices=labels or None,
             questions=questions_payload,
         ),
-    )):
+    )
+    try:
+        queued = client.enqueue(push)
+    except Exception as error:
+        # The push sidecar failed LOCALLY (worker startup, queue/runtime
+        # error): the relay will never park this decision, exactly like a
+        # queue-full drop. An optional-notification failure must never abort
+        # the tool call — use the native path immediately. Only the enqueue
+        # boundary is guarded; next_call's own exceptions propagate.
+        logger.warning(
+            "Conduit clarify notification enqueue failed; using native clarify path: %s",
+            error,
+        )
+        return kwargs["next_call"](args)
+    if not queued:
         # The event was dropped BEFORE delivery (local queue full): the relay
         # will never park this decision, so every poll is a phantom — the
         # unknown grace can only burn minutes before the inevitable native

--- a/clarify_loop.py
+++ b/clarify_loop.py
@@ -41,8 +41,12 @@ POLL_INTERVAL_SECONDS = 2.0
 # while the event POST and the first poll race (enqueue is async, delivery can
 # lag, relays blip). Past this the decision was never parked or the relay is
 # unreachable -- polling can never succeed -- so fall back to the original path
-# instead of polling the full budget.
-UNKNOWN_POLL_GRACE = 30  # ~60s at the base interval
+# instead of polling the full budget. The grace is ITERATION-based, so its
+# wall-clock span follows the backoff schedule: 30 consecutive unproductive
+# polls span 2+4+8 + 27*10 = ~284s (~4.75 min), NOT the ~60s a flat interval
+# would give. That is deliberate: it stays far under a default 3600s clarify
+# timeout while tolerating a long relay blip.
+UNKNOWN_POLL_GRACE = 30
 # Hard cap on polling even when the gateway configures an unlimited clarify
 # timeout; the relay expires pending decisions at 2h, and polling stops on
 # the unknown-after-pending transition well before this in practice.
@@ -112,7 +116,7 @@ def middleware(is_child_session: Callable[[str], bool] | None = None, **kwargs: 
         else None
     )
 
-    client.enqueue(push_event(
+    if not client.enqueue(push_event(
         "input.needed",
         identifier=event_id("input", kwargs.get("turn_id"), kwargs.get("tool_call_id"), request_id),
         session_id=session_id,
@@ -124,7 +128,12 @@ def middleware(is_child_session: Callable[[str], bool] | None = None, **kwargs: 
             choices=labels or None,
             questions=questions_payload,
         ),
-    ))
+    )):
+        # The event was dropped BEFORE delivery (local queue full): the relay
+        # will never park this decision, so every poll is a phantom — the
+        # unknown grace can only burn minutes before the inevitable native
+        # fallback. Use the native path immediately.
+        return kwargs["next_call"](args)
 
     return _first_answer_wins(
         request_id=request_id,

--- a/clarify_loop.py
+++ b/clarify_loop.py
@@ -42,10 +42,13 @@ POLL_INTERVAL_SECONDS = 2.0
 # lag, relays blip). Past this the decision was never parked or the relay is
 # unreachable -- polling can never succeed -- so fall back to the original path
 # instead of polling the full budget. The grace is ITERATION-based, so its
-# wall-clock span follows the backoff schedule: 30 consecutive unproductive
-# polls span 2+4+8 + 27*10 = ~284s (~4.75 min), NOT the ~60s a flat interval
-# would give. That is deliberate: it stays far under a default 3600s clarify
-# timeout while tolerating a long relay blip.
+# wall-clock span follows the backoff schedule: the break fires on the 30th
+# unproductive poll before its sleep, i.e. 29 sleeps of 2+4+8 + 26*10 =
+# ~274s (~4.6 min), NOT the ~60s a flat interval would give. That is
+# deliberate: it stays far under a default 3600s clarify timeout while
+# tolerating a long relay blip. (A locally DROPPED push never reaches this
+# loop at all -- enqueue reports the drop and the middleware falls back
+# immediately.)
 UNKNOWN_POLL_GRACE = 30
 # Hard cap on polling even when the gateway configures an unlimited clarify
 # timeout; the relay expires pending decisions at 2h, and polling stops on

--- a/client.py
+++ b/client.py
@@ -92,14 +92,25 @@ def unpair() -> bool:
     return True
 
 
-def enqueue(event: dict[str, Any]) -> None:
+def enqueue(event: dict[str, Any]) -> bool:
+    """Queue an event for asynchronous relay delivery.
+
+    Returns True when the event was accepted by the local delivery queue and
+    False when it was DROPPED (queue full, or the profile lost its pairing
+    between the caller's check and here). Fire-and-forget callers can ignore
+    the result; the clarify middleware MUST NOT — it parks a relay decision
+    on this event, so a drop has to fall back to the native clarify path
+    instead of polling an answer that can never arrive.
+    """
     if not load_state():
-        return
+        return False
     _start_worker()
     try:
         _events.put_nowait(event)
     except queue.Full:
         logger.warning("Conduit notification queue is full; dropping %s", event.get("type", "event"))
+        return False
+    return True
 
 
 def send_now(event: dict[str, Any], timeout: float = 15.0) -> dict[str, Any]:

--- a/relay/src/store.mjs
+++ b/relay/src/store.mjs
@@ -412,18 +412,23 @@ function hashSecret(value) {
   return createHash('sha256').update(value).digest('hex');
 }
 
-// Authentication-boundary digest comparison. Same SHA-256 hex digest and
-// persisted format as before — only the comparison changed: fixed-length
-// buffers are compared in constant time so response timing cannot leak how
-// much of a credential prefix matched. The length guard MUST come first
-// (timingSafeEqual throws on unequal lengths); a length difference can only
-// come from corrupt or foreign stored data, and length is not secret (a
-// well-formed sha256 hex digest is always 64 chars), so returning false is
-// correct. Lowercase-normalize the stored digest so decode behavior matches
-// the old case-sensitive string equality exactly.
+// Authentication-boundary digest comparison. Persisted hashes are CANONICAL:
+// exactly 64 lowercase hexadecimal characters — the output format of
+// hashSecret since the store was created. Anything else in the stored field
+// (corrupt, truncated, or manually edited state, including an uppercase
+// re-encoding) rejects before any comparison, keeping accepted state exactly
+// as narrow as the old case-sensitive string equality. For valid records the
+// two decoded 32-byte buffers are compared in constant time, so response
+// timing cannot leak how much of a credential prefix matched.
+const CANONICAL_SHA256_HEX = /^[0-9a-f]{64}$/;
+
 function secretMatches(candidate, expectedHash) {
+  const expectedText = String(expectedHash ?? '');
+  if (!CANONICAL_SHA256_HEX.test(expectedText)) return false;
   const actual = Buffer.from(hashSecret(candidate), 'hex');
-  const expected = Buffer.from(String(expectedHash ?? '').toLowerCase(), 'hex');
+  const expected = Buffer.from(expectedText, 'hex');
+  // Both sides are 32 bytes by construction; the guard stays defensive in
+  // case timingSafeEqual's throw-on-unequal-length contract ever changes.
   return actual.length === expected.length && timingSafeEqual(actual, expected);
 }
 

--- a/relay/src/store.mjs
+++ b/relay/src/store.mjs
@@ -419,10 +419,11 @@ function hashSecret(value) {
 // (timingSafeEqual throws on unequal lengths); a length difference can only
 // come from corrupt or foreign stored data, and length is not secret (a
 // well-formed sha256 hex digest is always 64 chars), so returning false is
-// correct.
+// correct. Lowercase-normalize the stored digest so decode behavior matches
+// the old case-sensitive string equality exactly.
 function secretMatches(candidate, expectedHash) {
   const actual = Buffer.from(hashSecret(candidate), 'hex');
-  const expected = Buffer.from(String(expectedHash ?? ''), 'hex');
+  const expected = Buffer.from(String(expectedHash ?? '').toLowerCase(), 'hex');
   return actual.length === expected.length && timingSafeEqual(actual, expected);
 }
 

--- a/relay/src/store.mjs
+++ b/relay/src/store.mjs
@@ -1,4 +1,4 @@
-import { createHash, randomBytes, randomUUID } from 'node:crypto';
+import { createHash, randomBytes, randomUUID, timingSafeEqual } from 'node:crypto';
 import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
 import { dirname } from 'node:path';
 
@@ -65,14 +65,14 @@ export class RelayStore {
     const installation = this.data.installations[id];
     if (!installation?.active || !secret) return null;
     const expected = scope === 'gateway' ? installation.gatewaySecretHash : installation.deviceSecretHash;
-    return expected && hashSecret(secret) === expected ? installation : null;
+    return expected && secretMatches(secret, expected) ? installation : null;
   }
 
   authenticateGateway(installationId, gatewayId, secret) {
     const installation = this.data.installations[installationId];
     const gateway = installation?.gateways?.[gatewayId];
     if (!installation?.active || !gateway || !secret) return null;
-    return hashSecret(secret) === gateway.secretHash ? { installation, gateway } : null;
+    return secretMatches(secret, gateway.secretHash) ? { installation, gateway } : null;
   }
 
   updateInstallation(id, changes) {
@@ -410,6 +410,20 @@ function publicInstallation(installation) {
 
 function hashSecret(value) {
   return createHash('sha256').update(value).digest('hex');
+}
+
+// Authentication-boundary digest comparison. Same SHA-256 hex digest and
+// persisted format as before — only the comparison changed: fixed-length
+// buffers are compared in constant time so response timing cannot leak how
+// much of a credential prefix matched. The length guard MUST come first
+// (timingSafeEqual throws on unequal lengths); a length difference can only
+// come from corrupt or foreign stored data, and length is not secret (a
+// well-formed sha256 hex digest is always 64 chars), so returning false is
+// correct.
+function secretMatches(candidate, expectedHash) {
+  const actual = Buffer.from(hashSecret(candidate), 'hex');
+  const expected = Buffer.from(String(expectedHash ?? ''), 'hex');
+  return actual.length === expected.length && timingSafeEqual(actual, expected);
 }
 
 function normalizeCode(value) {

--- a/relay/test/decisions.test.mjs
+++ b/relay/test/decisions.test.mjs
@@ -251,6 +251,15 @@ test('credential checks accept exact secrets and reject wrong or corrupt digests
     'cross-installation gateway credential rejected',
   );
 
+  // Canonical stored format: hashes are 64 LOWERCASE hex characters. An
+  // uppercase re-encoding of the otherwise-correct digest is noncanonical
+  // stored state and must reject rather than silently broaden what the
+  // store accepts.
+  const deviceSecretHash = relay.data.installations[installation.id].deviceSecretHash;
+  assert.ok(/^[0-9a-f]{64}$/.test(deviceSecretHash), 'hashSecret emits canonical lowercase sha256 hex');
+  relay.data.installations[installation.id].deviceSecretHash = deviceSecretHash.toUpperCase();
+  assert.equal(relay.authenticate(installation.id, deviceSecret, 'device'), null, 'uppercase noncanonical digest rejected');
+
   // A corrupt/truncated stored digest must reject cleanly — this is the
   // path that guards the timingSafeEqual unequal-length throw.
   relay.data.installations[installation.id].deviceSecretHash = 'deadbeef';

--- a/relay/test/decisions.test.mjs
+++ b/relay/test/decisions.test.mjs
@@ -218,3 +218,41 @@ test('pending decision store is bounded', () => {
   assert.equal(relay.pendingDecisionStatus('inst-1', 'gw-1', 'conduit-push-0').status, 'unknown');
   assert.equal(relay.pendingDecisionStatus('inst-1', 'gw-1', 'conduit-push-299').status, 'pending');
 });
+
+test('credential checks accept exact secrets and reject wrong or corrupt digests', () => {
+  // Auth-boundary contract for the constant-time digest comparison: same
+  // accept/reject behavior as before, wrong and corrupt secrets never pass,
+  // and unequal-length stored digests reject without throwing.
+  const relay = store();
+  const { installation, deviceSecret } = relay.createInstallation({
+    bundleId: 'com.milim.relay',
+    deviceToken: 'a'.repeat(64),
+    environment: 'production',
+  });
+  assert.ok(relay.authenticate(installation.id, deviceSecret, 'device'), 'correct device credential accepted');
+  assert.equal(relay.authenticate(installation.id, `${deviceSecret}0`, 'device'), null, 'wrong device credential rejected');
+  assert.equal(relay.authenticate(installation.id, '', 'device'), null, 'empty secret rejected');
+  assert.equal(relay.authenticate('missing-installation', deviceSecret, 'device'), null);
+
+  const pairing = relay.createPairing(installation.id);
+  const claimed = relay.claimPairing(pairing.code, 'auth gateway');
+  assert.ok(
+    relay.authenticateGateway(installation.id, claimed.gatewayId, claimed.gatewaySecret),
+    'correct gateway credential accepted',
+  );
+  assert.equal(
+    relay.authenticateGateway(installation.id, claimed.gatewayId, `${claimed.gatewaySecret}0`),
+    null,
+    'wrong gateway credential rejected',
+  );
+  assert.equal(
+    relay.authenticateGateway('some-other-installation', claimed.gatewayId, claimed.gatewaySecret),
+    null,
+    'cross-installation gateway credential rejected',
+  );
+
+  // A corrupt/truncated stored digest must reject cleanly — this is the
+  // path that guards the timingSafeEqual unequal-length throw.
+  relay.data.installations[installation.id].deviceSecretHash = 'deadbeef';
+  assert.equal(relay.authenticate(installation.id, deviceSecret, 'device'), null, 'corrupt stored digest rejects without throwing');
+});

--- a/relay/test/server.test.mjs
+++ b/relay/test/server.test.mjs
@@ -225,7 +225,12 @@ test('notificationFor strips an oversized batch decision so the card cannot exce
   assert.equal(payload.body.conduit.decision, undefined, 'the body copy must not carry a partial card either');
   assert.equal(JSON.stringify(payload).includes('"questions"'), false, 'no partial question list may survive anywhere in the payload');
   assert.equal(JSON.stringify(payload).includes('conduit-push-huge'), false, 'no answerable card fragments may survive');
-  assert.equal(Buffer.byteLength(JSON.stringify(payload)) <= 4096, true);
+  // The plain input.needed banner still ships alongside the stripped card.
+  assert.equal(payload.aps.alert.title, 'Input needed');
+  assert.equal(typeof payload.aps.alert.body, 'string');
+  // The stripped payload must fit under the same 3800-byte guard that
+  // triggered the strip (with the guard headroom to 4096 for transport).
+  assert.ok(Buffer.byteLength(JSON.stringify(payload)) <= 3800, 'stripped payload must fit under the guard threshold');
 });
 
 test('validateDecision preserves a sanitized batch and deduplicates identities', () => {

--- a/relay/test/server.test.mjs
+++ b/relay/test/server.test.mjs
@@ -196,6 +196,12 @@ test('notificationFor embeds every batch question in the rich body payload', () 
 });
 
 test('notificationFor strips an oversized batch decision so the card cannot exceed APNs limits', () => {
+  // A VALID protocol-max batch (8x8, maximal text): the answerable-card
+  // capacity is bounded by the APNs payload budget, not by the 8x8
+  // protocol ceiling. The degradation is ALL-OR-NOTHING — the serialized
+  // push must never carry a partial questions[] (Hermes is still waiting
+  // on every qid, so a truncated card would collect answers for a batch
+  // that can never complete) — and the plain banner still ships.
   const event = {
     type: 'input.needed',
     sessionId: 'sess-1',
@@ -214,7 +220,11 @@ test('notificationFor strips an oversized batch decision so the card cannot exce
   };
   const preferences = { enabled: true, show_previews: true, decision_cards: true };
   const { payload } = notificationFor(event, preferences);
+  // No decision in EITHER copy, and no partial questions anywhere.
   assert.equal(payload.conduit.decision, undefined, 'the size guard must strip the decision');
+  assert.equal(payload.body.conduit.decision, undefined, 'the body copy must not carry a partial card either');
+  assert.equal(JSON.stringify(payload).includes('"questions"'), false, 'no partial question list may survive anywhere in the payload');
+  assert.equal(JSON.stringify(payload).includes('conduit-push-huge'), false, 'no answerable card fragments may survive');
   assert.equal(Buffer.byteLength(JSON.stringify(payload)) <= 4096, true);
 });
 

--- a/tests/test_clarify_loop.py
+++ b/tests/test_clarify_loop.py
@@ -155,6 +155,35 @@ def test_queue_full_drop_uses_the_native_path_immediately_without_polling():
     assert fake.cancelled_ids == []
 
 
+def test_enqueue_exception_uses_the_native_path_without_polling():
+    # An UNEXPECTED enqueue failure (worker startup, queue/runtime error) is
+    # still just the optional push sidecar failing: the exception must not
+    # abort the tool call, and the relay never parked a decision — so the
+    # native path answers immediately, on the caller's thread, with no
+    # phantom polling and no release attempt.
+    fake = _FakeState([])
+
+    def broken_enqueue(event):
+        raise RuntimeError("worker startup failed")
+
+    fake.enqueue = broken_enqueue
+    _install(fake)
+    threads = []
+
+    def native(args):
+        threads.append(threading.current_thread().name)
+        return "native result"
+
+    result = loop.middleware(**_kwargs(native, {
+        "question": "Which environment?",
+        "choices": ["staging", "prod"],
+    }))
+    assert result == "native result"
+    assert threads == [threading.current_thread().name], "the native path must run on the caller's thread"
+    assert fake.poll_ids == [], "no phantom relay polling after an enqueue failure"
+    assert fake.cancelled_ids == []
+
+
 def test_enqueue_reports_whether_the_event_was_queued():
     # The boundary the clarify loop depends on: True while the delivery
     # queue has capacity, False once it is full (event dropped) or the

--- a/tests/test_clarify_loop.py
+++ b/tests/test_clarify_loop.py
@@ -184,6 +184,30 @@ def test_enqueue_exception_uses_the_native_path_without_polling():
     assert fake.cancelled_ids == []
 
 
+def test_native_path_exceptions_propagate_through_the_enqueue_guard():
+    # The guard exists only for the optional push sidecar: a failure raised
+    # by the NATIVE clarify path itself must reach the caller even when
+    # enqueue also failed — the fallback must never swallow it.
+    fake = _FakeState([])
+
+    def broken_enqueue(event):
+        raise RuntimeError("queue down")
+
+    fake.enqueue = broken_enqueue
+    _install(fake)
+
+    def broken_native(args):
+        raise RuntimeError("native clarify failed")
+
+    raised = None
+    try:
+        loop.middleware(**_kwargs(broken_native, {"question": "Q?"}))
+    except RuntimeError as error:
+        raised = error
+    assert raised is not None and "native clarify failed" in str(raised)
+    assert fake.poll_ids == []
+
+
 def test_enqueue_reports_whether_the_event_was_queued():
     # The boundary the clarify loop depends on: True while the delivery
     # queue has capacity, False once it is full (event dropped) or the

--- a/tests/test_clarify_loop.py
+++ b/tests/test_clarify_loop.py
@@ -73,6 +73,8 @@ class _FakeState:
 
     def enqueue(self, event):
         self.enqueued.append(event)
+        # Match the real boundary: True = accepted by the delivery queue.
+        return True
 
     def cancel_decision(self, request_id):
         # Stubbed so tests stay hermetic: the real client would attempt an
@@ -120,6 +122,48 @@ def test_unpaired_profile_keeps_original_path_only():
     result = loop.middleware(**_kwargs(lambda a: "original", {"question": "Q?"}))
     assert result == "original"
     assert fake.enqueued == []
+
+
+def test_queue_full_drop_uses_the_native_path_immediately_without_polling():
+    # enqueue returning False means the event was dropped BEFORE delivery
+    # (local queue full): the relay will never park the decision, so polling
+    # is phantom work that can only burn the unknown grace before the
+    # inevitable native fallback. The middleware must skip the race
+    # entirely — no thread, no poll_decision calls, native answer now.
+    fake = _FakeState([])
+    dropped = []
+    fake.enqueue = lambda event: dropped.append(event) or False
+    _install(fake)
+    result = loop.middleware(**_kwargs(lambda a: "native result", {
+        "question": "Which environment?",
+        "choices": ["staging", "prod"],
+    }))
+    assert result == "native result"
+    assert len(dropped) == 1, "the clarify event was attempted exactly once"
+    assert fake.enqueued == []
+    assert fake.poll_ids == [], "no phantom relay polling after a local drop"
+    assert fake.cancelled_ids == []
+
+
+def test_enqueue_reports_whether_the_event_was_queued():
+    # The boundary the clarify loop depends on: True while the delivery
+    # queue has capacity, False once it is full (event dropped).
+    import queue as queue_module
+
+    # Earlier tests in this file install fakes onto the shared client
+    # module; reload so the GENUINE enqueue boundary is under test.
+    importlib.reload(loop.client)
+    loop.client.load_state = lambda: {"credential": "x"}  # paired, without touching the filesystem
+    original_events = loop.client._events
+    original_worker_started = loop.client._worker_started
+    loop.client._events = queue_module.Queue(maxsize=1)
+    loop.client._worker_started = True  # keep the delivery worker unspawned
+    try:
+        assert loop.client.enqueue({"type": "response.ready"}) is True
+        assert loop.client.enqueue({"type": "response.ready"}) is False, "a full queue must drop and report False"
+    finally:
+        loop.client._events = original_events
+        loop.client._worker_started = original_worker_started
 
 
 def test_relay_answer_wins_and_formats_like_the_builtin_tool():

--- a/tests/test_clarify_loop.py
+++ b/tests/test_clarify_loop.py
@@ -134,11 +134,21 @@ def test_queue_full_drop_uses_the_native_path_immediately_without_polling():
     dropped = []
     fake.enqueue = lambda event: dropped.append(event) or False
     _install(fake)
-    result = loop.middleware(**_kwargs(lambda a: "native result", {
+    threads = []
+
+    def native(args):
+        threads.append(threading.current_thread().name)
+        return "native result"
+
+    result = loop.middleware(**_kwargs(native, {
         "question": "Which environment?",
         "choices": ["staging", "prod"],
     }))
     assert result == "native result"
+    # Deterministic regression proof: on the pre-fix code next_call ran on
+    # the spawned "conduit-push-clarify" daemon thread; with the fix it runs
+    # synchronously on the caller's thread.
+    assert threads == [threading.current_thread().name]
     assert len(dropped) == 1, "the clarify event was attempted exactly once"
     assert fake.enqueued == []
     assert fake.poll_ids == [], "no phantom relay polling after a local drop"
@@ -147,21 +157,26 @@ def test_queue_full_drop_uses_the_native_path_immediately_without_polling():
 
 def test_enqueue_reports_whether_the_event_was_queued():
     # The boundary the clarify loop depends on: True while the delivery
-    # queue has capacity, False once it is full (event dropped).
+    # queue has capacity, False once it is full (event dropped) or the
+    # profile lost its pairing.
     import queue as queue_module
 
     # Earlier tests in this file install fakes onto the shared client
     # module; reload so the GENUINE enqueue boundary is under test.
     importlib.reload(loop.client)
-    loop.client.load_state = lambda: {"credential": "x"}  # paired, without touching the filesystem
+    original_load_state = loop.client.load_state
     original_events = loop.client._events
     original_worker_started = loop.client._worker_started
     loop.client._events = queue_module.Queue(maxsize=1)
     loop.client._worker_started = True  # keep the delivery worker unspawned
     try:
+        loop.client.load_state = lambda: {"credential": "x"}  # paired, without touching the filesystem
         assert loop.client.enqueue({"type": "response.ready"}) is True
         assert loop.client.enqueue({"type": "response.ready"}) is False, "a full queue must drop and report False"
+        loop.client.load_state = lambda: None  # unpaired: nothing can be delivered
+        assert loop.client.enqueue({"type": "response.ready"}) is False, "an unpaired profile must report False"
     finally:
+        loop.client.load_state = original_load_state
         loop.client._events = original_events
         loop.client._worker_started = original_worker_started
 

--- a/tests/test_clarify_relay_e2e.py
+++ b/tests/test_clarify_relay_e2e.py
@@ -245,11 +245,14 @@ def _run_clarify(monkeypatch, args):
         # before replying to /v1/events, so a returned send_now guarantees
         # the decision is findable by the test's /respond request. Appending
         # in finally keeps the event visible for diagnosis if the send raises
-        # (the holder error then fails the test loudly).
+        # (the holder error then fails the test loudly). Returns True — this
+        # stands in for client.enqueue, whose boolean the middleware now
+        # reads to detect a local drop.
         try:
             real_send_now(event)
         finally:
             events.append(event)
+        return True
 
     monkeypatch.setattr(loop.client, "enqueue", capture_and_send)
     release = threading.Event()


### PR DESCRIPTION
Focused post-merge hardening after #10 / Conduit #127. No protocol changes — scalar/batch semantics, per-qid locking, 409/410/400 behavior, release, and the single-copy APNs payload layout are untouched.

## 1. Queue-full clarify phantom polling
`client.enqueue` now returns **True** (accepted by the delivery queue) / **False** (dropped: queue full, or pairing lost). The clarify middleware treats a drop as never-parked and uses the native Hermes clarify path **immediately** — previously a queue-full drop entered the relay race and phantom-polled the full unknown grace (~4.6 min under backoff) before the inevitable fallback. Ordinary fire-and-forget callers (the five `__init__.py` hook sites) ignore the return and are unaffected. The stale "~60s" unknown-grace comment is corrected to the backoff-accurate ~274s.

## 2. Batch-capacity documentation
README + the oversized-batch unit test now distinguish:
- **8 questions × 8 choices** = the protocol/store validation ceiling, and
- **answerable push-card capacity** = bounded by Apple's ~4 KB APNs payload limit (depends on actual text byte size).
A valid batch over the payload budget is **never truncated or split** (Hermes is still waiting on every qid): the whole decision is stripped from both payload copies, the plain `input.needed` banner ships, and the decision is parked `deliverable=false`. The unit test now asserts all-or-nothing explicitly (no decision, no `questions` fragment, no card id anywhere in the payload; banner survives; ≤ guard threshold).

## 3. Constant-time credential digest comparison
`relay/src/store.mjs` gains `secretMatches(candidate, expectedHash)`: SHA-256 hex digests (same representation, same persisted format) compared with `timingSafeEqual`, length-guarded before the call, stored digest lowercase-normalized for exact parity with the old case-sensitive equality. Used by `authenticate()` (device + gateway scopes) and `authenticateGateway()`. Credential generation, endpoint behavior, and status codes unchanged.

## Verification
- pytest: 56/56 (incl. the real-process plugin ↔ relay e2e; new queue-full + enqueue-boundary tests fail on the parent commit)
- `node --test relay/test/*.test.mjs`: 38/38 (incl. device/gateway credential accept/reject/corrupt-digest tests and the strengthened all-or-nothing oversized-batch test)
- `git diff --check`: clean
- Multi-model review: 3× APPROVE; all non-blocking findings applied